### PR TITLE
 Add Linux example (tested on Ubuntu 18.04)

### DIFF
--- a/freertos-cargo-build/src/lib.rs
+++ b/freertos-cargo-build/src/lib.rs
@@ -179,6 +179,7 @@ impl Builder {
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default(); // none, windows, linux, macos
         let port = match (target.as_str(), target_arch.as_str(), target_os.as_str(), target_env.as_str()) {
             (_, "x86_64", "windows", _) => "MSVC-MingW",
+            (_, "x86_64", "linux", "gnu") => "GCC/Linux",
             ("thumbv7m-none-eabi", _, _, _) => "GCC/ARM_CM3",
             // TODO We should support feature "trustzone"
             ("thumbv8m.main-none-eabi", _, _, _) => "GCC/ARM_CM33_NTZ/non_secure",

--- a/freertos-rust-examples/Cargo.toml
+++ b/freertos-rust-examples/Cargo.toml
@@ -29,5 +29,8 @@ nrf9160-pac = "0.2.1"
 # Example: win
 [target.x86_64-pc-windows-gnu.dependencies]
 
+# Example: linux
+[target.x86_64-unknown-linux-gnu.dependencies]
+
 [build-dependencies]
 freertos-cargo-build = {path = "../freertos-cargo-build"}

--- a/freertos-rust-examples/FreeRTOS/Source/portable/GCC/Linux/README.md
+++ b/freertos-rust-examples/FreeRTOS/Source/portable/GCC/Linux/README.md
@@ -1,0 +1,3 @@
+## Linux port of FreeRTOS
+* This is not an official port maintained by the FreeRTOS team
+* This port is from `https://github.com/michaelbecker/freertos-addons`

--- a/freertos-rust-examples/FreeRTOS/Source/portable/GCC/Linux/port.c
+++ b/freertos-rust-examples/FreeRTOS/Source/portable/GCC/Linux/port.c
@@ -1,0 +1,886 @@
+/*
+ *  Copyright (C) 2017 Michael Becker (michael.f.becker@gmail.com
+ *  Modified from code from William Davy (william.davy@wittenstein.co.uk)
+ *
+ *  Modifications (not exhaustive):
+ *  ---------------------------------------------
+ *  + Updated to work with FreeRTOS v8.2.3
+ *
+ *  + Updated code that works with pthreads to 
+ *    treat pthread_t data as opaque data structures,
+ *    as specified in the POSIX standard. Likewise, 
+ *    cannot initialize them to NULL, not portable.
+ *
+ *  + Since FreeRTOS is not multicore, we are forcing 
+ *    all of the pthreads that simulate FreeRTOS tasks 
+ *    to execute on a single core.
+ *
+ */
+/*
+    Copyright (C) 2009 William Davy - william.davy@wittenstein.co.uk
+    Contributed to FreeRTOS.org V5.3.0.
+
+    This file is part of the FreeRTOS.org distribution.
+
+    FreeRTOS.org is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License (version 2) as published
+    by the Free Software Foundation and modified by the FreeRTOS exception.
+
+    FreeRTOS.org is distributed in the hope that it will be useful,    but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+    more details.
+
+    You should have received a copy of the GNU General Public License along
+    with FreeRTOS.org; if not, write to the Free Software Foundation, Inc., 59
+    Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+
+    A special exception to the GPL is included to allow you to distribute a
+    combined work that includes FreeRTOS.org without being obliged to provide
+    the source code for any proprietary components.  See the licensing section
+    of http://www.FreeRTOS.org for full details.
+
+
+    ***************************************************************************
+    *                                                                         *
+    * Get the FreeRTOS eBook!  See http://www.FreeRTOS.org/Documentation      *
+    *                                                                         *
+    * This is a concise, step by step, 'hands on' guide that describes both   *
+    * general multitasking concepts and FreeRTOS specifics. It presents and   *
+    * explains numerous examples that are written using the FreeRTOS API.     *
+    * Full source code for all the examples is provided in an accompanying    *
+    * .zip file.                                                              *
+    *                                                                         *
+    ***************************************************************************
+
+    1 tab == 4 spaces!
+
+    Please ensure to read the configuration and relevant port sections of the
+    online documentation.
+
+    http://www.FreeRTOS.org - Documentation, latest information, license and
+    contact details.
+
+    http://www.SafeRTOS.com - A version that is certified for use in safety
+    critical systems.
+
+    http://www.OpenRTOS.com - Commercial support, development, porting,
+    licensing and training services.
+*/
+
+/*-----------------------------------------------------------
+ * Implementation of functions defined in portable.h for the Posix port.
+ *----------------------------------------------------------*/
+
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <sched.h>
+#include <signal.h>
+#include <errno.h>
+#include <sys/time.h>
+#include <time.h>
+#include <sys/times.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <limits.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <assert.h>
+#include <string.h>
+
+/* Scheduler includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "portmacro.h"
+
+
+/* Each task maintains its own interrupt status in the critical nesting variable. */
+typedef struct ThreadState_t_
+{
+    pthread_t       Thread;
+    int             Valid;    /* Treated as a boolean */
+    xTaskHandle     hTask;
+    portBASE_TYPE   uxCriticalNesting;
+    pdTASK_CODE     pxCode;
+    void            *pvParams;
+    int             index;
+
+} ThreadState_t;
+
+
+#define MAX_NUMBER_OF_TASKS ( _POSIX_THREAD_THREADS_MAX )
+static ThreadState_t pxThreads[MAX_NUMBER_OF_TASKS];
+
+static pthread_once_t hSigSetupThread = PTHREAD_ONCE_INIT;
+
+static pthread_mutex_t xSuspendResumeThreadMutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t xSingleThreadMutex = PTHREAD_MUTEX_INITIALIZER;
+
+static pthread_t hMainThread;
+static pthread_t hEndSchedulerCallerThread;
+int hEndSchedulerCallerThreadIndex;
+
+static volatile portBASE_TYPE xSentinel = 0;
+static volatile portBASE_TYPE xSchedulerEnd = pdFALSE;
+static volatile portBASE_TYPE xInterruptsEnabled = pdTRUE;
+static volatile portBASE_TYPE xServicingTick = pdFALSE;
+static volatile portBASE_TYPE xPendYield = pdFALSE;
+static volatile portLONG lIndexOfLastAddedTask = 0;
+static volatile portBASE_TYPE uxCriticalNesting;
+
+
+/**
+ *  pthread cleanup routine, always executed on pthread exit.
+ */
+static void DeleteThreadCleanupRoutine( void *Parameter )
+{
+    ThreadState_t *State = (ThreadState_t *)Parameter;
+
+#if LINUX_PORT_DEBUG
+    printf("[%d] DeleteThreadCleanupRoutine for index\n", State->index);
+#endif
+
+    State->Valid = 0;
+    State->hTask = (xTaskHandle)NULL;
+    if ( State->uxCriticalNesting > 0 )
+    {
+        State->uxCriticalNesting = 0;
+        uxCriticalNesting = 0;
+        vPortEnableInterrupts();
+    }
+}
+
+
+/**
+ *  Sends SIG_SUSPEND to target thread.
+ */
+static void SuspendThread( pthread_t Thread )
+{
+    pthread_mutex_lock( &xSuspendResumeThreadMutex );
+
+    /* Set-up for the Suspend Signal handler? */
+    xSentinel = 0;
+    pthread_mutex_unlock( &xSuspendResumeThreadMutex );
+
+    pthread_kill( Thread, SIG_SUSPEND );
+    while ( ( xSentinel == 0 ) && ( pdTRUE != xServicingTick ) )
+    {
+        sched_yield();
+    }
+}
+
+
+/**
+ *  Signal handler for SIG_SUSPEND
+ */
+static void SuspendSignalHandler(int sig)
+{
+    sigset_t xSignals;
+    int rc;
+
+    /* Only interested in the resume signal. */
+    sigemptyset( &xSignals );
+    sigaddset( &xSignals, SIG_RESUME );
+    xSentinel = 1;
+
+    /* Unlock the Single thread mutex to allow the resumed task to continue. */
+    rc = pthread_mutex_unlock(&xSingleThreadMutex);
+    assert(rc == 0);
+
+    /* Wait on the resume signal. */
+    rc = sigwait(&xSignals, &sig);
+    assert(rc == 0);
+
+    /* Will resume here when the SIG_RESUME signal is received. */
+    /* Need to set the interrupts based on the task's critical nesting. */
+    if ( uxCriticalNesting == 0 )
+    {
+        vPortEnableInterrupts();
+    }
+    else
+    {
+        vPortDisableInterrupts();
+    }
+}
+
+
+/**
+ *  Signal handler for SIG_RESUME.
+ */
+static void ResumeSignalHandler(int sig)
+{
+    (void)sig;
+
+    /* Yield the Scheduler to ensure that the yielding thread completes. */
+    if (pthread_mutex_lock(&xSingleThreadMutex) == 0) {
+        pthread_mutex_unlock(&xSingleThreadMutex);
+    }
+}
+
+
+/**
+ *  Sends SIG_RESUME to target thread.
+ */
+static void ResumeThread( pthread_t Thread )
+{
+    int rc;
+
+    rc = pthread_mutex_lock(&xSuspendResumeThreadMutex);
+    assert(rc == 0);
+
+    if ( !pthread_equal(pthread_self(), Thread))
+    {
+        pthread_kill( Thread, SIG_RESUME );
+    }
+
+    pthread_mutex_unlock( &xSuspendResumeThreadMutex );
+}
+
+
+/**
+ *  Utility function to lookup a pthread_t based on 
+ *  a FreeRTOS Task Handle.
+ */
+static int LookupThread(xTaskHandle hTask, pthread_t *Thread)
+{
+    int i;
+    
+    for (i = 0; i < MAX_NUMBER_OF_TASKS; i++)
+    {
+        if (pxThreads[i].hTask == hTask)
+        {
+            *Thread = pxThreads[i].Thread;
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
+static void prvSetTaskCriticalNesting( pthread_t Thread, portBASE_TYPE uxNesting )
+{
+    int i;
+
+    for (i = 0; i < MAX_NUMBER_OF_TASKS; i++)
+    {
+        if ( pthread_equal(pxThreads[i].Thread, Thread) )
+        {
+            pxThreads[i].uxCriticalNesting = uxNesting;
+            return;
+        }
+    }
+
+    assert(!"Failed finding pthread for task mapping!");
+}
+
+
+static portBASE_TYPE prvGetTaskCriticalNesting( pthread_t Thread )
+{
+    unsigned portBASE_TYPE uxNesting = 0;
+    int i;
+
+    for (i = 0; i < MAX_NUMBER_OF_TASKS; i++)
+    {
+        if ( pthread_equal(pxThreads[i].Thread, Thread) )
+        {
+            uxNesting = pxThreads[i].uxCriticalNesting;
+            return uxNesting;
+        }
+    }
+    
+    assert(!"Failed finding pthread for task mapping!");
+}
+
+
+/**
+ *  Signal handler for SIG_TICK.
+ */
+static void TickSignalHandler( int sig )
+{
+    pthread_t ThreadToSuspend;
+    pthread_t ThreadToResume;
+    int success;
+
+    (void)sig;
+
+    if ((pdTRUE == xInterruptsEnabled) && (pdTRUE != xServicingTick))
+    {
+        if ( 0 == pthread_mutex_trylock( &xSingleThreadMutex ) )
+        {
+            xServicingTick = pdTRUE;
+
+            /*
+             *  Required call for newer FreeRTOS kernels
+             */
+            xTaskIncrementTick();
+
+            success = LookupThread(xTaskGetCurrentTaskHandle(), &ThreadToSuspend);
+            assert(success);
+
+            /* Select Next Task. */
+#if ( configUSE_PREEMPTION == 1 )
+            vTaskSwitchContext();
+#endif
+            success = LookupThread(xTaskGetCurrentTaskHandle(), &ThreadToResume);
+            assert(success);
+
+            /* The only thread that can process this tick is the running thread. */
+            if ( !pthread_equal(ThreadToSuspend, ThreadToResume) )
+            {
+                /* Remember and switch the critical nesting. */
+                prvSetTaskCriticalNesting( ThreadToSuspend, uxCriticalNesting );
+                uxCriticalNesting = prvGetTaskCriticalNesting( ThreadToResume );
+                /* Resume next task. */
+                ResumeThread( ThreadToResume );
+                /* Suspend the current task. */
+                SuspendThread( ThreadToSuspend );
+            }
+            else
+            {
+                /* Release the lock as we are Resuming. */
+                pthread_mutex_unlock( &xSingleThreadMutex );
+            }
+            xServicingTick = pdFALSE;
+        }
+        else
+        {
+            xPendYield = pdTRUE;
+        }
+    }
+    else
+    {
+        xPendYield = pdTRUE;
+    }
+}
+
+
+/**
+ *  Only run once!
+ */
+static void prvSetupSignalsAndSchedulerPolicy( void )
+{
+    /* The following code would allow for configuring the scheduling of this task as a Real-time task.
+     * The process would then need to be run with higher privileges for it to take affect.
+    int iPolicy;
+    int iResult;
+    int iSchedulerPriority;
+    iResult = pthread_getschedparam( pthread_self(), &iPolicy, &iSchedulerPriority );
+    iResult = pthread_attr_setschedpolicy( &xThreadAttributes, SCHED_FIFO );
+    iPolicy = SCHED_FIFO;
+    iResult = pthread_setschedparam( pthread_self(), iPolicy, &iSchedulerPriority );        */
+
+    int i;
+    struct sigaction sigsuspendself, sigresume, sigtick;
+
+    memset(pxThreads, 0, sizeof(pxThreads));
+
+    for (i = 0; i < MAX_NUMBER_OF_TASKS; i++ )
+    {
+        pxThreads[i].index = i;
+    }
+    
+
+    sigsuspendself.sa_flags = 0;
+    sigsuspendself.sa_handler = SuspendSignalHandler;
+    sigfillset( &sigsuspendself.sa_mask );
+
+    sigresume.sa_flags = 0;
+    sigresume.sa_handler = ResumeSignalHandler;
+    sigfillset( &sigresume.sa_mask );
+
+    sigtick.sa_flags = 0;
+    sigtick.sa_handler = TickSignalHandler;
+    sigfillset( &sigtick.sa_mask );
+
+    if ( 0 != sigaction( SIG_SUSPEND, &sigsuspendself, NULL ) )
+    {
+        assert( !"Problem installing SIG_SUSPEND_SELF\n" );
+    }
+    if ( 0 != sigaction( SIG_RESUME, &sigresume, NULL ) )
+    {
+        assert( !"Problem installing SIG_RESUME\n" );
+    }
+    if ( 0 != sigaction( SIG_TICK, &sigtick, NULL ) )
+    {
+        assert( !"Problem installing SIG_TICK\n" );
+    }
+
+#if LINUX_PORT_DEBUG
+    printf( "Running as PID: %d\n", getpid() );
+#endif
+
+    /*
+     *  Also save the first thread as the main thread.
+     */
+    hMainThread = pthread_self();
+}
+
+
+/**
+ *  Actual pthreads code, wrapper around FreeRTOS task.
+ */
+static void *ThreadStartWrapper( void * pvParams )
+{
+    ThreadState_t *State = (ThreadState_t *)pvParams;
+
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+    
+    pthread_cleanup_push( DeleteThreadCleanupRoutine, State );
+
+    pthread_mutex_lock(&xSingleThreadMutex); 
+    SuspendThread( pthread_self() );
+
+#if LINUX_PORT_DEBUG
+    printf("[%d] Starting thread\n", State->index);
+#endif
+
+    State->pxCode( State->pvParams );
+
+#if LINUX_PORT_DEBUG
+    printf("[%d] Ending thread - SHOULD NEVER SEE THIS\n", State->index);
+#endif
+
+    /* make sure we execute DeleteThreadCleanupRoutine */
+    pthread_cleanup_pop( 1 );
+
+    return (void *)NULL;
+}
+
+
+/*
+ * See header file for description.
+ */
+portSTACK_TYPE *pxPortInitialiseStack( portSTACK_TYPE *pxTopOfStack, pdTASK_CODE pxCode, void *pvParameters )
+{
+    int rc;
+    int i;
+    pthread_attr_t xThreadAttributes;
+    cpu_set_t cpuset;
+ 
+    pthread_once( &hSigSetupThread, prvSetupSignalsAndSchedulerPolicy );
+
+    /* No need to join the threads. */
+    pthread_attr_init( &xThreadAttributes );
+    pthread_attr_setdetachstate( &xThreadAttributes, PTHREAD_CREATE_DETACHED );
+
+    vPortEnterCritical();
+
+    for (i = 0; i < MAX_NUMBER_OF_TASKS; i++ )
+    {
+        if (pxThreads[i].Valid == 0)
+        {
+            lIndexOfLastAddedTask = i;
+            break;
+        }
+    }
+
+    /* No more free threads, please increase the maximum. */
+    assert(i < MAX_NUMBER_OF_TASKS);
+
+
+    /* Add the task parameters. */
+    pxThreads[lIndexOfLastAddedTask].pxCode = pxCode;
+    pxThreads[lIndexOfLastAddedTask].pvParams = pvParameters;
+
+    /* Create the new pThread. */
+    rc = pthread_mutex_lock(&xSingleThreadMutex);
+    assert(rc == 0);
+
+    xSentinel = 0;
+
+    rc = pthread_create(&pxThreads[lIndexOfLastAddedTask].Thread, 
+                        &xThreadAttributes, 
+                        ThreadStartWrapper, 
+                        (void *)&pxThreads[lIndexOfLastAddedTask]
+                        );
+    assert(rc == 0);
+
+    CPU_ZERO(&cpuset);
+    CPU_SET(0, &cpuset);
+
+    rc = pthread_setaffinity_np(pxThreads[lIndexOfLastAddedTask].Thread, 
+                                sizeof(cpu_set_t), 
+                                &cpuset);
+	configASSERT( rc == 0 );
+    pxThreads[lIndexOfLastAddedTask].Valid = 1;
+
+
+    /* Wait until the task suspends. */
+    pthread_mutex_unlock( &xSingleThreadMutex );
+
+    while ( xSentinel == 0 );
+    vPortExitCritical();
+
+    return pxTopOfStack;
+}
+
+
+/*
+ * Setup the systick timer to generate the tick interrupts at the required
+ * frequency.
+ */
+static void prvSetupTimerInterrupt( void )
+{
+    int rc;
+    struct itimerval itimer, oitimer;
+    suseconds_t MicroSeconds = (suseconds_t)(portTICK_RATE_MICROSECONDS % 1000000);
+    time_t Seconds = portTICK_RATE_MICROSECONDS / 1000000;
+
+    /* Initialise the structure with the current timer information. */
+    rc = getitimer( TIMER_TYPE, &itimer);
+    assert(rc == 0);
+
+    /* Set the interval between timer events. */
+    itimer.it_interval.tv_sec = Seconds;
+    itimer.it_interval.tv_usec = MicroSeconds;
+
+    /* Set the current count-down. */
+    itimer.it_value.tv_sec = Seconds;
+    itimer.it_value.tv_usec = MicroSeconds;
+
+#if LINUX_PORT_DEBUG
+    printf("Timer Setup:\n");
+    printf("  Interval: %ld seconds, %ld useconds\n", 
+            itimer.it_interval.tv_sec, itimer.it_interval.tv_usec);
+    printf("  Current: %ld seconds, %ld useconds\n", 
+            itimer.it_value.tv_sec, itimer.it_value.tv_usec);
+#endif
+
+    /* Set-up the timer interrupt. */
+    rc = setitimer( TIMER_TYPE, &itimer, &oitimer );
+    assert(rc == 0);
+}
+
+
+/*
+ * See header file for description.
+ */
+portBASE_TYPE xPortStartScheduler( void )
+{
+    int iSignal;
+    sigset_t xSignals;
+    sigset_t xSignalToBlock;
+    sigset_t xSignalsBlocked;
+    pthread_t FirstThread;
+    int success;
+
+#if LINUX_PORT_DEBUG
+    printf("\n***** LINUX PORT CONFIGURED FOR DEBUG *****\n");
+#endif    
+
+
+    /* Establish the signals to block before they are needed. */
+    sigfillset( &xSignalToBlock );
+
+    /* Block until the end */
+    pthread_sigmask( SIG_SETMASK, &xSignalToBlock, &xSignalsBlocked );
+
+    /* Start the timer that generates the tick ISR.  Interrupts are disabled
+    here already. */
+    prvSetupTimerInterrupt();
+
+    /* Start the first task. Will not return unless all threads are killed. */
+    /* Initialise the critical nesting count ready for the first task. */
+    uxCriticalNesting = 0;
+
+    vPortEnableInterrupts();
+
+    success = LookupThread( xTaskGetCurrentTaskHandle(), &FirstThread);
+    assert(success);
+
+    /* Start the first task. */
+    ResumeThread(FirstThread);
+
+
+    /* This is the end signal we are looking for. */
+    sigemptyset( &xSignals );
+    sigaddset( &xSignals, SIG_RESUME );
+
+    while ( pdTRUE != xSchedulerEnd )
+    {
+        if ( 0 != sigwait( &xSignals, &iSignal ) )
+        {
+            printf( "Main thread spurious signal: %d\n", iSignal );
+        }
+    }
+
+#if LINUX_PORT_DEBUG
+    printf("Exiting scheduler.\n");
+    printf("[%d] Canceling xTaskEndScheduler caller thread.\n", hEndSchedulerCallerThreadIndex);
+#endif
+
+    pthread_cancel(hEndSchedulerCallerThread);
+    sleep(1);
+
+    /* Cleanup the mutexes */
+#if LINUX_PORT_DEBUG
+    printf( "Freeing OS mutexes.\n" );
+#endif
+
+    pthread_mutex_destroy( &xSuspendResumeThreadMutex );
+    pthread_mutex_destroy( &xSingleThreadMutex );
+
+    sleep(1);
+
+    /* Should not get here! */
+    return 0;
+}
+
+
+void vPortEndScheduler( void )
+{
+    int i;
+    int rc;
+    struct sigaction sigtickdeinit;
+
+    xInterruptsEnabled = pdFALSE;
+
+    /* Signal the scheduler to exit its loop. */
+    xSchedulerEnd = pdTRUE;
+
+    /* Ignore next or pending SIG_TICK, it mustn't execute anymore. */
+    sigtickdeinit.sa_flags = 0;
+    sigtickdeinit.sa_handler = SIG_IGN;
+    sigfillset(&sigtickdeinit.sa_mask);
+
+    rc = sigaction(SIG_TICK, &sigtickdeinit, NULL);
+    assert(rc == 0);
+
+    rc = sigaction(SIG_RESUME, &sigtickdeinit, NULL);
+    assert(rc == 0);
+
+    rc = sigaction(SIG_SUSPEND, &sigtickdeinit, NULL);
+    assert(rc == 0);
+    
+
+    for (i = 0; i < MAX_NUMBER_OF_TASKS; i++)
+    {
+        if ( pxThreads[i].Valid )
+        {
+            //pxThreads[i].Valid = 0;
+                
+            /* Don't kill yourself */
+            if (pthread_equal(pxThreads[i].Thread, pthread_self())) 
+            {
+#if LINUX_PORT_DEBUG
+                printf("[%d] Delaying canceling pthread\n", i);
+#endif                
+                hEndSchedulerCallerThread = pxThreads[i].Thread;
+                hEndSchedulerCallerThreadIndex = pxThreads[i].index;
+                continue;
+            }
+            else
+            {
+                /* Kill all of the threads, they are in the detached state. */
+#if LINUX_PORT_DEBUG
+                printf("[%d] canceling pthread\n", i);
+#endif                
+                pthread_cancel(pxThreads[i].Thread );
+                sleep(1);
+            }
+        }
+    }
+
+    pthread_kill( hMainThread, SIG_RESUME );
+}
+
+
+void vPortYieldFromISR( void )
+{
+    /* Calling Yield from a Interrupt/Signal handler often doesn't work because the
+     * xSingleThreadMutex is already owned by an original call to Yield. Therefore,
+     * simply indicate that a yield is required soon.
+     */
+    xPendYield = pdTRUE;
+}
+
+
+void vPortEnterCritical( void )
+{
+    vPortDisableInterrupts();
+    uxCriticalNesting++;
+}
+
+
+void vPortExitCritical( void )
+{
+    /* Check for unmatched exits. */
+    if ( uxCriticalNesting > 0 )
+    {
+        uxCriticalNesting--;
+    }
+
+    /* If we have reached 0 then re-enable the interrupts. */
+    if( uxCriticalNesting == 0 )
+    {
+        /* Have we missed ticks? This is the equivalent of pending an interrupt. */
+        if ( pdTRUE == xPendYield )
+        {
+            xPendYield = pdFALSE;
+            vPortYield();
+        }
+        vPortEnableInterrupts();
+    }
+}
+
+
+void vPortYield( void )
+{
+    int rc;
+    pthread_t ThreadToSuspend;
+    pthread_t ThreadToResume;
+    int success;
+
+    rc = pthread_mutex_lock(&xSingleThreadMutex);
+    assert(rc == 0);
+
+    success = LookupThread(xTaskGetCurrentTaskHandle(), &ThreadToSuspend);
+    assert(success);
+
+    vTaskSwitchContext();
+
+    success = LookupThread(xTaskGetCurrentTaskHandle(), &ThreadToResume);
+    assert(success);
+
+    if ( !pthread_equal(ThreadToSuspend, ThreadToResume) )
+    {
+        /* Remember and switch the critical nesting. */
+        prvSetTaskCriticalNesting( ThreadToSuspend, uxCriticalNesting );
+        uxCriticalNesting = prvGetTaskCriticalNesting( ThreadToResume );
+        /* Switch tasks. */
+        ResumeThread( ThreadToResume );
+        SuspendThread( ThreadToSuspend );
+    }
+    else
+    {
+        /* Yielding to self */
+        pthread_mutex_unlock( &xSingleThreadMutex );
+    }
+}
+
+
+void vPortDisableInterrupts( void )
+{
+    xInterruptsEnabled = pdFALSE;
+}
+
+
+void vPortEnableInterrupts( void )
+{
+    xInterruptsEnabled = pdTRUE;
+}
+
+
+portBASE_TYPE xPortSetInterruptMask( void )
+{
+    portBASE_TYPE xReturn = xInterruptsEnabled;
+    xInterruptsEnabled = pdFALSE;
+    return xReturn;
+}
+
+
+void vPortClearInterruptMask( portBASE_TYPE xMask )
+{
+    xInterruptsEnabled = xMask;
+}
+
+
+/**
+ *  Public API used in tasks.c
+ */
+void vPortForciblyEndThread( void *pxTaskToDelete )
+{
+    xTaskHandle hTaskToDelete = ( xTaskHandle )pxTaskToDelete;
+    pthread_t ThreadToDelete;
+    pthread_t ThreadToResume;
+    int success;
+
+    pthread_mutex_lock(&xSingleThreadMutex);
+
+    success = LookupThread(hTaskToDelete, &ThreadToDelete);
+    (void)success;
+
+    LookupThread(xTaskGetCurrentTaskHandle(), &ThreadToResume);
+
+    if ( pthread_equal(ThreadToResume, ThreadToDelete) )
+    {
+        /* This is a suicidal thread, need to select a different task to run. */
+        vTaskSwitchContext();
+        LookupThread(xTaskGetCurrentTaskHandle(), &ThreadToResume);
+    }
+
+    if ( !pthread_equal(pthread_self(), ThreadToDelete) )
+    {
+        /* Cancelling a thread that is not me. */
+ 
+        /* Send a signal to wake the task so that it definitely cancels. */
+        pthread_testcancel();
+        pthread_cancel( ThreadToDelete );
+ 
+        /* Pthread Clean-up function will note the cancellation. */
+        pthread_mutex_unlock( &xSingleThreadMutex );
+    }
+    else
+    {
+        /* Resume the other thread. */
+        ResumeThread( ThreadToResume );
+        /* Pthread Clean-up function will note the cancellation. */
+        /* Release the execution. */
+        uxCriticalNesting = 0;
+        vPortEnableInterrupts();
+        pthread_mutex_unlock( &xSingleThreadMutex );
+        /* Commit suicide */
+        pthread_exit( (void *)1 );
+    }
+}
+
+
+/**
+ *  Used for traceTASK_CREATE in FreeRTOS.
+ */
+void vPortAddTaskHandle( void *pxTaskHandle )
+{
+    int i;
+
+    pxThreads[lIndexOfLastAddedTask].hTask = (xTaskHandle)pxTaskHandle;
+
+    for (i = 0; i < MAX_NUMBER_OF_TASKS; i++)
+    {
+        if ( pthread_equal(pxThreads[i].Thread, pxThreads[lIndexOfLastAddedTask].Thread))
+        {
+            if ( pxThreads[i].hTask != pxThreads[ lIndexOfLastAddedTask ].hTask )
+            {
+                pxThreads[i].Valid = 0;
+                pxThreads[i].hTask = NULL;
+                pxThreads[i].uxCriticalNesting = 0;
+            }
+        }
+    }
+}
+
+
+void vPortFindTicksPerSecond( void )
+{
+    /* Needs to be reasonably high for accuracy. */
+    unsigned long ulTicksPerSecond = sysconf(_SC_CLK_TCK);
+    printf( "Timer Resolution for Run TimeStats is %ld ticks per second.\n", ulTicksPerSecond );
+}
+
+
+unsigned long ulPortGetTimerValue( void )
+{
+    struct tms xTimes;
+
+    (void)times( &xTimes );
+    /* Return the application code times.
+     * The timer only increases when the application code is actually running
+     * which means that the total execution times should add up to 100%.
+     */
+    return ( unsigned long ) xTimes.tms_utime;
+}
+
+
+

--- a/freertos-rust-examples/FreeRTOS/Source/portable/GCC/Linux/portmacro.h
+++ b/freertos-rust-examples/FreeRTOS/Source/portable/GCC/Linux/portmacro.h
@@ -1,0 +1,188 @@
+/*
+	FreeRTOS.org V5.2.0 - Copyright (C) 2003-2009 Richard Barry.
+
+	This file is part of the FreeRTOS.org distribution.
+
+	FreeRTOS.org is free software; you can redistribute it and/or modify it
+	under the terms of the GNU General Public License (version 2) as published
+	by the Free Software Foundation and modified by the FreeRTOS exception.
+
+	FreeRTOS.org is distributed in the hope that it will be useful,	but WITHOUT
+	ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+	more details.
+
+	You should have received a copy of the GNU General Public License along
+	with FreeRTOS.org; if not, write to the Free Software Foundation, Inc., 59
+	Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+
+	A special exception to the GPL is included to allow you to distribute a
+	combined work that includes FreeRTOS.org without being obliged to provide
+	the source code for any proprietary components.  See the licensing section
+	of http://www.FreeRTOS.org for full details.
+
+
+	***************************************************************************
+	*                                                                         *
+	* Get the FreeRTOS eBook!  See http://www.FreeRTOS.org/Documentation      *
+	*                                                                         *
+	* This is a concise, step by step, 'hands on' guide that describes both   *
+	* general multitasking concepts and FreeRTOS specifics. It presents and   *
+	* explains numerous examples that are written using the FreeRTOS API.     *
+	* Full source code for all the examples is provided in an accompanying    *
+	* .zip file.                                                              *
+	*                                                                         *
+	***************************************************************************
+
+	1 tab == 4 spaces!
+
+	Please ensure to read the configuration and relevant port sections of the
+	online documentation.
+
+	http://www.FreeRTOS.org - Documentation, latest information, license and
+	contact details.
+
+	http://www.SafeRTOS.com - A version that is certified for use in safety
+	critical systems.
+
+	http://www.OpenRTOS.com - Commercial support, development, porting,
+	licensing and training services.
+*/
+
+
+#ifndef PORTMACRO_H
+#define PORTMACRO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <unistd.h>
+#include <stdint.h>    
+
+/*-----------------------------------------------------------
+ * Port specific definitions.
+ *
+ * The settings in this file configure FreeRTOS correctly for the
+ * given hardware and compiler.
+ *
+ * These settings should not be altered.
+ *-----------------------------------------------------------
+ */
+
+/* Type definitions. */
+#define portCHAR		char
+#define portFLOAT		float
+#define portDOUBLE		double
+#define portLONG		int
+#define portSHORT		short
+#define portSTACK_TYPE  unsigned long
+#define portBASE_TYPE   long
+#define portPOINTER_SIZE_TYPE size_t
+
+typedef portSTACK_TYPE StackType_t;
+typedef long BaseType_t;
+typedef unsigned long UBaseType_t;
+
+
+#if( configUSE_16_BIT_TICKS == 1 )
+    typedef uint16_t TickType_t;
+	#define portMAX_DELAY ( portTickType ) 0xffff
+#else
+    typedef uint32_t TickType_t;
+	#define portMAX_DELAY ( portTickType ) 0xffffffff
+#endif
+/*-----------------------------------------------------------*/
+
+/* Architecture specifics. */
+#define portSTACK_GROWTH			( -1 )
+#define portTICK_PERIOD_MS			( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+#define portTICK_RATE_MICROSECONDS		( ( portTickType ) 1000000 / configTICK_RATE_HZ )
+#define portINLINE __inline
+
+#if defined( __x86_64__) || defined( _M_X64 )
+	#define portBYTE_ALIGNMENT		8
+#else
+	#define portBYTE_ALIGNMENT		4
+#endif
+
+#define portREMOVE_STATIC_QUALIFIER
+/*-----------------------------------------------------------*/
+
+
+/* Scheduler utilities. */
+extern void vPortYieldFromISR( void );
+extern void vPortYield( void );
+
+#define portYIELD()					vPortYield()
+
+#define portEND_SWITCHING_ISR( xSwitchRequired ) if( xSwitchRequired ) vPortYieldFromISR()
+/*-----------------------------------------------------------*/
+
+
+/* Critical section management. */
+extern void vPortDisableInterrupts( void );
+extern void vPortEnableInterrupts( void );
+#define portSET_INTERRUPT_MASK()	( vPortDisableInterrupts() )
+#define portCLEAR_INTERRUPT_MASK()	( vPortEnableInterrupts() )
+
+extern portBASE_TYPE xPortSetInterruptMask( void );
+extern void vPortClearInterruptMask( portBASE_TYPE xMask );
+
+#define portSET_INTERRUPT_MASK_FROM_ISR()		xPortSetInterruptMask()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR(x)	vPortClearInterruptMask(x)
+
+
+extern void vPortEnterCritical( void );
+extern void vPortExitCritical( void );
+
+#define portDISABLE_INTERRUPTS()	portSET_INTERRUPT_MASK()
+#define portENABLE_INTERRUPTS()		portCLEAR_INTERRUPT_MASK()
+#define portENTER_CRITICAL()		vPortEnterCritical()
+#define portEXIT_CRITICAL()			vPortExitCritical()
+/*-----------------------------------------------------------*/
+
+
+#ifndef configUSE_PORT_OPTIMISED_TASK_SELECTION
+	#define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
+#endif
+
+#if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
+#error We are not supporting configUSE_PORT_OPTIMISED_TASK_SELECTION in the Linux Simulator.
+#endif 
+
+
+/* Task function macros as described on the FreeRTOS.org WEB site. */
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters ) void vFunction( void *pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters ) void vFunction( void *pvParameters )
+
+#define portNOP()
+
+#define portOUTPUT_BYTE( a, b )
+
+extern void vPortForciblyEndThread( void *pxTaskToDelete );
+#define traceTASK_DELETE( pxTaskToDelete )		vPortForciblyEndThread( pxTaskToDelete )
+
+extern void vPortAddTaskHandle( void *pxTaskHandle );
+#define traceTASK_CREATE( pxNewTCB )			vPortAddTaskHandle( pxNewTCB )
+
+/* Posix Signal definitions that can be changed or read as appropriate. */
+#define SIG_SUSPEND					SIGUSR1
+#define SIG_RESUME					SIGUSR2
+
+/* Enable the following hash defines to make use of the real-time tick where time progresses at real-time.*/ 
+#define SIG_TICK					SIGALRM
+#define TIMER_TYPE					ITIMER_REAL 
+/* Enable the following hash defines to make use of the process tick where time progresses only when the process is executing.
+#define SIG_TICK					SIGVTALRM
+#define TIMER_TYPE					ITIMER_VIRTUAL */
+/* Enable the following hash defines to make use of the profile tick where time progresses when the process or system calls are executing.
+#define SIG_TICK					SIGPROF
+#define TIMER_TYPE					ITIMER_PROF */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PORTMACRO_H */
+

--- a/freertos-rust-examples/README.md
+++ b/freertos-rust-examples/README.md
@@ -29,7 +29,7 @@ Install required/useful tooling
 
 ### Build
 
-    cargo build -example win
+    cargo build --example win
     
 **Note:** An example for linux is very welcome :)
     
@@ -50,8 +50,20 @@ Prepare the build with:
 Run the build
 
     cargo run --package freertos-rust-examples --example win --target x86_64-pc-windows-msvc
-    
-### Run STM32 Coretex M3 Demo
+
+### Run Linux Demo
+
+
+Prepare the build with:
+
+    rustup default x86_64-unknown-linux-gnu
+    rustup target add x86_64-unknown-linux-gnu
+
+Run the build
+
+    cargo run --package freertos-rust-examples --example linux --target x86_64-unknown-linux-gnu
+
+### Run STM32 Cortex-M3 Demo
 
 we need the nightly build for some features like allocator_api:
 

--- a/freertos-rust-examples/build.rs
+++ b/freertos-rust-examples/build.rs
@@ -28,6 +28,13 @@ fn main() {
         }
     }
 
+    if target == "x86_64-unknown-linux-gnu" {
+        b.freertos_config("examples/linux");
+
+        b.get_cc().file("examples/linux/hooks.c");
+        // b.get_cc().file("examples/linux/Run-time-stats-utils.c"); // Unimplemented yet..
+    }
+
     if target == "thumbv7m-none-eabi" {
         b.freertos_config("examples/stm32-cortex-m3");
         copy(

--- a/freertos-rust-examples/examples/linux/FreeRTOSConfig.h
+++ b/freertos-rust-examples/examples/linux/FreeRTOSConfig.h
@@ -1,0 +1,156 @@
+/*
+    FreeRTOS V8.2.3 - Copyright (C) 2015 Real Time Engineers Ltd.
+    All rights reserved
+    VISIT http://www.FreeRTOS.org TO ENSURE YOU ARE USING THE LATEST VERSION.
+    This file is part of the FreeRTOS distribution.
+    FreeRTOS is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License (version 2) as published by the
+    Free Software Foundation >>>> AND MODIFIED BY <<<< the FreeRTOS exception.
+    ***************************************************************************
+    >>!   NOTE: The modification to the GPL is included to allow you to     !<<
+    >>!   distribute a combined work that includes FreeRTOS without being   !<<
+    >>!   obliged to provide the source code for proprietary components     !<<
+    >>!   outside of the FreeRTOS kernel.                                   !<<
+    ***************************************************************************
+    FreeRTOS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  Full license text is available on the following
+    link: http://www.freertos.org/a00114.html
+    ***************************************************************************
+     *                                                                       *
+     *    FreeRTOS provides completely free yet professionally developed,    *
+     *    robust, strictly quality controlled, supported, and cross          *
+     *    platform software that is more than just the market leader, it     *
+     *    is the industry's de facto standard.                               *
+     *                                                                       *
+     *    Help yourself get started quickly while simultaneously helping     *
+     *    to support the FreeRTOS project by purchasing a FreeRTOS           *
+     *    tutorial book, reference manual, or both:                          *
+     *    http://www.FreeRTOS.org/Documentation                              *
+     *                                                                       *
+    ***************************************************************************
+    http://www.FreeRTOS.org/FAQHelp.html - Having a problem?  Start by reading
+    the FAQ page "My application does not run, what could be wrong?".  Have you
+    defined configASSERT()?
+    http://www.FreeRTOS.org/support - In return for receiving this top quality
+    embedded software for free we request you assist our global community by
+    participating in the support forum.
+    http://www.FreeRTOS.org/training - Investing in training allows your team to
+    be as productive as possible as early as possible.  Now you can receive
+    FreeRTOS training directly from Richard Barry, CEO of Real Time Engineers
+    Ltd, and the world's leading authority on the world's leading RTOS.
+    http://www.FreeRTOS.org/plus - A selection of FreeRTOS ecosystem products,
+    including FreeRTOS+Trace - an indispensable productivity tool, a DOS
+    compatible FAT file system, and our tiny thread aware UDP/IP stack.
+    http://www.FreeRTOS.org/labs - Where new FreeRTOS products go to incubate.
+    Come and try FreeRTOS+TCP, our new open source TCP/IP stack for FreeRTOS.
+    http://www.OpenRTOS.com - Real Time Engineers ltd. license FreeRTOS to High
+    Integrity Systems ltd. to sell under the OpenRTOS brand.  Low cost OpenRTOS
+    licenses offer ticketed support, indemnification and commercial middleware.
+    http://www.SafeRTOS.com - High Integrity Systems also provide a safety
+    engineered and independently SIL3 certified version for use in safety and
+    mission critical applications that require provable dependability.
+    1 tab == 4 spaces!
+*/
+
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*-----------------------------------------------------------
+ * Application specific definitions.
+ *
+ * These definitions should be adjusted for your particular hardware and
+ * application requirements.
+ *
+ * THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+ * FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+ *----------------------------------------------------------*/
+
+#define configUSE_PREEMPTION					1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION	0
+#define configUSE_IDLE_HOOK						0
+#define configUSE_TICK_HOOK						0
+#define configTICK_RATE_HZ						( 1000 ) 
+#define configMINIMAL_STACK_SIZE				( ( unsigned short ) 50 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the win32 thread. */
+#define configTOTAL_HEAP_SIZE					( ( size_t ) ( 23 * 1024 ) )
+#define configMAX_TASK_NAME_LEN					( 12 )
+#define configUSE_TRACE_FACILITY				1
+#define configUSE_16_BIT_TICKS					0
+#define configIDLE_SHOULD_YIELD					1
+#define configUSE_MUTEXES						1
+#define configCHECK_FOR_STACK_OVERFLOW			0
+#define configUSE_RECURSIVE_MUTEXES				1
+#define configQUEUE_REGISTRY_SIZE				20
+#define configUSE_MALLOC_FAILED_HOOK			1
+#define configUSE_APPLICATION_TASK_TAG			1
+#define configUSE_COUNTING_SEMAPHORES			1
+#define configUSE_QUEUE_SETS					1
+#define configUSE_TASK_NOTIFICATIONS			1
+
+/* Software timer related configuration options. */
+#define configUSE_TIMERS						1
+#define configTIMER_TASK_PRIORITY				( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH				20
+#define configTIMER_TASK_STACK_DEPTH			( configMINIMAL_STACK_SIZE * 2 )
+
+#define configMAX_PRIORITIES					( 7 )
+
+/* Run time stats gathering configuration options. */
+unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that returns run time counter. */
+#define configGENERATE_RUN_TIME_STATS			1
+/* Make use of times(man 2) to gather run-time statistics on the tasks. */
+extern void vPortFindTicksPerSecond( void );
+#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() vPortFindTicksPerSecond()
+extern unsigned long ulPortGetTimerValue( void );
+#define portGET_RUN_TIME_COUNTER_VALUE() ulPortGetTimerValue()
+
+/* Co-routine related configuration options. */
+#define configUSE_CO_ROUTINES 					1
+#define configMAX_CO_ROUTINE_PRIORITIES			( 2 )
+
+/* This demo makes use of one or more example stats formatting functions.  These
+format the raw data provided by the uxTaskGetSystemState() function in to human
+readable ASCII form.  See the notes in the implementation of vTaskList() within
+FreeRTOS/Source/tasks.c for limitations. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS	1
+
+/* Set the following definitions to 1 to include the API function, or zero
+to exclude the API function.  In most cases the linker will remove unused
+functions anyway. */
+#define INCLUDE_vTaskPrioritySet				1
+#define INCLUDE_uxTaskPriorityGet				1
+#define INCLUDE_vTaskDelete						1
+#define INCLUDE_vTaskCleanUpResources			0
+#define INCLUDE_vTaskSuspend					1
+#define INCLUDE_vTaskDelayUntil					1
+#define INCLUDE_vTaskDelay						1
+#define INCLUDE_uxTaskGetStackHighWaterMark		1
+#define INCLUDE_xTaskGetSchedulerState			1
+#define INCLUDE_xTimerGetTimerDaemonTaskHandle	1
+#define INCLUDE_xTaskGetIdleTaskHandle			1
+#define INCLUDE_pcTaskGetTaskName				1
+#define INCLUDE_eTaskGetState					1
+#define INCLUDE_xSemaphoreGetMutexHolder		1
+#define INCLUDE_xTimerPendFunctionCall			1
+
+/* It is a good idea to define configASSERT() while developing.  configASSERT()
+uses the same semantics as the standard C assert() macro. */
+extern void vAssertCalled( unsigned long ulLine, const char * const pcFileName );
+#define configASSERT( x ) if( ( x ) == 0 ) vAssertCalled( __LINE__, __FILE__ )
+
+/* Include the FreeRTOS+Trace FreeRTOS trace macro definitions. */
+#define TRACE_ENTER_CRITICAL_SECTION() portENTER_CRITICAL()
+#define TRACE_EXIT_CRITICAL_SECTION() portEXIT_CRITICAL()
+/*#include "trcKernelPort.h" */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* FREERTOS_CONFIG_H */

--- a/freertos-rust-examples/examples/linux/hooks.c
+++ b/freertos-rust-examples/examples/linux/hooks.c
@@ -1,0 +1,132 @@
+/* Standard includes. */
+#include <stdio.h>
+#include <stdlib.h>
+
+/* FreeRTOS kernel includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/*
+ * Prototypes for the standard FreeRTOS application hook (callback) functions
+ * implemented within this file.  See http://www.freertos.org/a00016.html .
+ */
+void vApplicationMallocFailedHook(void);
+void vApplicationIdleHook(void);
+void vApplicationStackOverflowHook(TaskHandle_t pxTask, char *pcTaskName);
+void vApplicationTickHook(void);
+void vApplicationGetIdleTaskMemory(StaticTask_t **ppxIdleTaskTCBBuffer, StackType_t **ppxIdleTaskStackBuffer, uint32_t *pulIdleTaskStackSize);
+void vApplicationGetTimerTaskMemory(StaticTask_t **ppxTimerTaskTCBBuffer, StackType_t **ppxTimerTaskStackBuffer, uint32_t *pulTimerTaskStackSize);
+
+/*-----------------------------------------------------------*/
+
+/* When configSUPPORT_STATIC_ALLOCATION is set to 1 the application writer can
+use a callback function to optionally provide the memory required by the idle
+and timer tasks.  This is the stack that will be used by the timer task.  It is
+declared here, as a global, so it can be checked by a test that is implemented
+in a different file. */
+StackType_t uxTimerTaskStack[configTIMER_TASK_STACK_DEPTH];
+
+void vApplicationMallocFailedHook(void) {
+	/* vApplicationMallocFailedHook() will only be called if
+	configUSE_MALLOC_FAILED_HOOK is set to 1 in FreeRTOSConfig.h.  It is a hook
+	function that will get called if a call to pvPortMalloc() fails.
+	pvPortMalloc() is called internally by the kernel whenever a task, queue,
+	timer or semaphore is created.  It is also called by various parts of the
+	demo application.  If heap_1.c, heap_2.c or heap_4.c is being used, then the
+	size of the	heap available to pvPortMalloc() is defined by
+	configTOTAL_HEAP_SIZE in FreeRTOSConfig.h, and the xPortGetFreeHeapSize()
+	API function can be used to query the size of free heap space that remains
+	(although it does not provide information on how the remaining heap might be
+	fragmented).  See http://www.freertos.org/a00111.html for more
+	information. */
+	configASSERT(1);
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationIdleHook(void) {
+	/* vApplicationIdleHook() will only be called if configUSE_IDLE_HOOK is set
+	to 1 in FreeRTOSConfig.h.  It will be called on each iteration of the idle
+	task.  It is essential that code added to this hook function never attempts
+	to block in any way (for example, call xQueueReceive() with a block time
+	specified, or call vTaskDelay()).  If application tasks make use of the
+	vTaskDelete() API function to delete themselves then it is also important
+	that vApplicationIdleHook() is permitted to return to its calling function,
+	because it is the responsibility of the idle task to clean up memory
+	allocated by the kernel to any task that has since deleted itself. */
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationStackOverflowHook(TaskHandle_t pxTask, char *pcTaskName) {
+	(void) pcTaskName;
+	(void) pxTask;
+
+	/* Run time stack overflow checking is performed if
+	configCHECK_FOR_STACK_OVERFLOW is defined to 1 or 2.  This hook
+	function is called if a stack overflow is detected.  This function is
+	provided as an example only as stack overflow checking does not function
+	when running the FreeRTOS Windows port. */
+	configASSERT(1);
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationTickHook(void) {
+	/* This function will be called by each tick interrupt if
+	configUSE_TICK_HOOK is set to 1 in FreeRTOSConfig.h.  User code can be
+	added here, but the tick hook is called from an interrupt context, so
+	code must not attempt to block, and only the interrupt safe FreeRTOS API
+	functions can be used (those that end in FromISR()). */
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationDaemonTaskStartupHook(void) {
+	/* This function will be called once only, when the daemon task starts to
+	execute	(sometimes called the timer task).  This is useful if the
+	application includes initialisation code that would benefit from executing
+	after the scheduler has been started. */
+}
+/*-----------------------------------------------------------*/
+
+/* configUSE_STATIC_ALLOCATION is set to 1, so the application must provide an
+implementation of vApplicationGetIdleTaskMemory() to provide the memory that is
+used by the Idle task. */
+void vApplicationGetIdleTaskMemory(StaticTask_t **ppxIdleTaskTCBBuffer, StackType_t **ppxIdleTaskStackBuffer, uint32_t *pulIdleTaskStackSize) {
+/* If the buffers to be provided to the Idle task are declared inside this
+function then they must be declared static - otherwise they will be allocated on
+the stack and so not exists after this function exits. */
+	static StaticTask_t xIdleTaskTCB;
+	static StackType_t uxIdleTaskStack[configMINIMAL_STACK_SIZE];
+
+	/* Pass out a pointer to the StaticTask_t structure in which the Idle task's
+	state will be stored. */
+	*ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
+
+	/* Pass out the array that will be used as the Idle task's stack. */
+	*ppxIdleTaskStackBuffer = uxIdleTaskStack;
+
+	/* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
+	Note that, as the array is necessarily of type StackType_t,
+	configMINIMAL_STACK_SIZE is specified in words, not bytes. */
+	*pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+}
+/*-----------------------------------------------------------*/
+/* configUSE_STATIC_ALLOCATION and configUSE_TIMERS are both set to 1, so the
+application must provide an implementation of vApplicationGetTimerTaskMemory()
+to provide the memory that is used by the Timer service task. */
+void vApplicationGetTimerTaskMemory(StaticTask_t **ppxTimerTaskTCBBuffer, StackType_t **ppxTimerTaskStackBuffer, uint32_t *pulTimerTaskStackSize) {
+/* If the buffers to be provided to the Timer task are declared inside this
+function then they must be declared static - otherwise they will be allocated on
+the stack and so not exists after this function exits. */
+	static StaticTask_t xTimerTaskTCB;
+
+	/* Pass out a pointer to the StaticTask_t structure in which the Timer
+	task's state will be stored. */
+	*ppxTimerTaskTCBBuffer = &xTimerTaskTCB;
+
+	/* Pass out the array that will be used as the Timer task's stack. */
+	*ppxTimerTaskStackBuffer = uxTimerTaskStack;
+
+	/* Pass out the size of the array pointed to by *ppxTimerTaskStackBuffer.
+	Note that, as the array is necessarily of type StackType_t,
+	configMINIMAL_STACK_SIZE is specified in words, not bytes. */
+	*pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
+}

--- a/freertos-rust-examples/examples/linux/main.rs
+++ b/freertos-rust-examples/examples/linux/main.rs
@@ -1,0 +1,46 @@
+use freertos_rust::*;
+
+#[global_allocator]
+static GLOBAL: FreeRtosAllocator = FreeRtosAllocator;
+
+
+fn main() {
+    let x = Box::new(15);
+    println!("Boxed int '{}' (allocator test)", x);
+
+    unsafe {
+        FREERTOS_HOOKS.set_on_assert(|| { println!("Assert hook called") });
+    }
+
+    //println!("Calling assert ...");
+    //FreeRtosUtils::invoke_assert();
+
+    println!("Starting FreeRTOS app ...");
+    Task::new().name("hello").stack_size(128).priority(TaskPriority(2)).start(|| {
+        let mut i = 0;
+        loop {
+            println!("Hello from Task! {}", i);
+            CurrentTask::delay(Duration::ms(1000));
+            i = i + 1;
+        }
+    }).unwrap();
+    println!("Task registered");
+    //let free = freertos_rs_xPortGetFreeHeapSize();
+    // println!("Free Memory: {}!", free);
+    println!("Starting scheduler");
+    FreeRtosUtils::start_scheduler();
+    loop {
+        println!("Loop forever!");
+    }
+}
+
+#[test]
+fn many_boxes() {
+    init_allocator();
+    println!("many_boxes... ");
+    for i in 0..10 { // .. HEAP_SIZE
+        let x = Box::new(i);
+        assert_eq!(*x, i);
+    }
+    println!("[ok]");
+}


### PR DESCRIPTION
Hello :crab: , this PR contains the following changes.
* add a linux port of FreeRTOS from https://github.com/michaelbecker/freertos-addons
* add a Linux example
  (It runs successfully on Ubuntu 18.04. (`cargo run --example linux`))

I made this PR after seeing issue #1 .
Unlike the Windows example, I haven't yet ported **'Run-time-stats-utils.c'**  for Linux,
but at least there are no issues running the example.

Thank you for reviewing this PR :) :superhero: 