### PR TITLE
Examples fixes to start with the required task handlers

### DIFF
--- a/freertos-rust-examples/examples/linux/main.rs
+++ b/freertos-rust-examples/examples/linux/main.rs
@@ -16,7 +16,7 @@ fn main() {
     //FreeRtosUtils::invoke_assert();
 
     println!("Starting FreeRTOS app ...");
-    Task::new().name("hello").stack_size(128).priority(TaskPriority(2)).start(|| {
+    Task::new().name("hello").stack_size(128).priority(TaskPriority(2)).start(|_this_task| {
         let mut i = 0;
         loop {
             println!("Hello from Task! {}", i);

--- a/freertos-rust-examples/examples/nrf9160/main.rs
+++ b/freertos-rust-examples/examples/nrf9160/main.rs
@@ -70,7 +70,7 @@ fn do_blink() {
 fn main() -> ! {
     //asm::nop(); // To not have main optimize to abort in release mode, remove when you add code
 
-    let h = Task::new().name("hello").stack_size(512).priority(TaskPriority(1)).start(|| {
+    let h = Task::new().name("hello").stack_size(512).priority(TaskPriority(1)).start(|_this_task| {
         // Blink forever
         do_blink();
         loop {

--- a/freertos-rust-examples/examples/stm32-cortex-m3/FreeRTOSConfig.h
+++ b/freertos-rust-examples/examples/stm32-cortex-m3/FreeRTOSConfig.h
@@ -74,9 +74,9 @@
 extern void vAssertCalled( unsigned long ulLine, const char * const pcFileName );
 #define configASSERT( x ) if( ( x ) == 0 ) vAssertCalled( __LINE__, __FILE__ )
 
-#define vPortSVCHandler SVC_Handler
-#define xPortPendSVHandler PendSV_Handler
-#define xPortSysTickHandler SysTick_Handler
+#define vPortSVCHandler SVCall
+#define xPortPendSVHandler PendSV
+#define xPortSysTickHandler SysTick 
 
 /*-----------------------------------------------------------
  * Application specific definitions.

--- a/freertos-rust-examples/examples/stm32-cortex-m3/main.rs
+++ b/freertos-rust-examples/examples/stm32-cortex-m3/main.rs
@@ -75,7 +75,7 @@ fn main() -> ! {
 
     // TODO: What comes now does not work yet!
     // Initialize Tasks and start FreeRTOS
-    Task::new().name("hello").stack_size(128).priority(TaskPriority(1)).start(|| {
+    Task::new().name("hello").stack_size(128).priority(TaskPriority(1)).start(|_this_task| {
         // Just blink
         freertos_rust::CurrentTask::delay(Duration::ms(1000));
         set_led(true);

--- a/freertos-rust-examples/examples/win/main.rs
+++ b/freertos-rust-examples/examples/win/main.rs
@@ -16,7 +16,7 @@ fn main() {
     //FreeRtosUtils::invoke_assert();
 
     println!("Starting FreeRTOS app ...");
-    Task::new().name("hello").stack_size(128).priority(TaskPriority(2)).start(|| {
+    Task::new().name("hello").stack_size(128).priority(TaskPriority(2)).start(|_this_task| {
         let mut i = 0;
         loop {
             println!("Hello from Task! {}", i);


### PR DESCRIPTION
With the addition of task handlers #8, the examples were broken 