### PR TITLE
Removes unused type bound on heap manager C build handler

### DIFF
--- a/freertos-cargo-build/src/lib.rs
+++ b/freertos-cargo-build/src/lib.rs
@@ -145,7 +145,7 @@ impl Builder {
     /// Set the heap_?.c file to use from the "/portable/MemMang/" folder.
     /// heap_1.c ... heap_5.c (Default: heap_4.c)
     /// see also: https://www.freertos.org/a00111.html
-    pub fn heap<P: AsRef<Path>>(&mut self, file_name: String) {
+    pub fn heap(&mut self, file_name: String) {
         self.heap_c = file_name;
     }
 


### PR DESCRIPTION
This is a fairly trivial fix for the issue observed in:
https://github.com/lobaro/FreeRTOS-rust/issues/11

However, the Path nature of the C file for the heap manager does not appear to be used.