### PR TITLE
Add detection for thumbv7em-none-eabi (CM4 without FPU)

### DIFF
--- a/freertos-cargo-build/src/lib.rs
+++ b/freertos-cargo-build/src/lib.rs
@@ -181,6 +181,7 @@ impl Builder {
             (_, "x86_64", "windows", _) => "MSVC-MingW",
             (_, "x86_64", "linux", "gnu") => "GCC/Linux",
             ("thumbv7m-none-eabi", _, _, _) => "GCC/ARM_CM3",
+            ("thumbv7em-none-eabi", _, _, _) => "GCC/ARM_CM3", // M4 cores without FPU use M3
             ("thumbv7em-none-eabihf", _, _, _) => "GCC/ARM_CM4F",
             // TODO We should support feature "trustzone"
             ("thumbv8m.main-none-eabi", _, _, _) => "GCC/ARM_CM33_NTZ/non_secure",


### PR DESCRIPTION
Cortex-M4 cores that don't have (or don't enable) FPU should use the CM3 port. This just adds this case to the table so it is automatically detected for the user.