### PR TITLE
Add freertos_rs_suspend_task()

### DIFF
--- a/freertos-rust/src/freertos/shim.c
+++ b/freertos-rust/src/freertos/shim.c
@@ -222,6 +222,10 @@ void freertos_rs_delete_task(TaskHandle_t task) {
 }
 #endif
 
+void freertos_rs_suspend_task(TaskHandle_t task) {
+	vTaskSuspend(task);
+}
+
 UBaseType_t freertos_rs_get_stack_high_water_mark(TaskHandle_t task) {
 #if (INCLUDE_uxTaskGetStackHighWaterMark == 1)
 	return uxTaskGetStackHighWaterMark(task);


### PR DESCRIPTION
`freertos_rs_suspend_task()` was added to shim.rs as part of #19, but the corresponding C function was not. This adds it and avoids a build breakage due to it missing.