### PR TITLE
Re-run build.rs when C files change

### DIFF
--- a/freertos-cargo-build/src/lib.rs
+++ b/freertos-cargo-build/src/lib.rs
@@ -1,4 +1,5 @@
 use cc::Build;
+use std::ffi::OsStr;
 use std::fmt::Display;
 use std::{fmt, env};
 use std::path::{Path, PathBuf};
@@ -240,26 +241,72 @@ impl Builder {
 
         self.verify_paths()?;
 
-        // FreeRTOS header files
-        b.include(self.freertos_include_dir());
-        // FreeRTOS port header files (e.g. portmacro.h)
-        b.include(self.get_freertos_port_dir());
-        b.include(self.freertos_config_dir.clone());
-        b.file(self.heap_c_file());
-        self.freertos_files().iter().for_each(|f| {
-            b.file(f);
-        });
-        self.freertos_port_files().iter().for_each(|f| {
-            b.file(f);
-        });
-        self.freertos_shim_files().iter().for_each(|f| {
-            b.file(f);
-        });
+        add_include_with_rerun(&mut b, self.freertos_include_dir()); // FreeRTOS header files
+        add_include_with_rerun(&mut b, self.get_freertos_port_dir()); // FreeRTOS port header files (e.g. portmacro.h)
+        add_include_with_rerun(&mut b, &self.freertos_config_dir); // User's FreeRTOSConfig.h
+
+        add_build_files_with_rerun(&mut b, self.freertos_files()); // Non-port C files
+        add_build_files_with_rerun(&mut b, self.freertos_port_files()); // Port C files
+        add_build_files_with_rerun(&mut b, self.freertos_shim_files()); // Shim C file
+        add_build_file_with_rerun(&mut b, self.heap_c_file()); // Heap C file
+
+        println!("cargo:rerun-if-env-changed={ENV_KEY_FREERTOS_SRC}");
+        println!("cargo:rerun-if-env-changed={ENV_KEY_FREERTOS_CONFIG}");
+        println!("cargo:rerun-if-env-changed={ENV_KEY_FREERTOS_SHIM}");
 
         b.try_compile("freertos").map_err(|e| Error::new(&format!("{}", e)))?;
 
         Ok(())
     }
+
+    /// Add a single file to the build. This also tags the file with cargo:rerun-if-changed so that cargo will re-run
+    /// the build script if the file changes. If you don't want this additional behavior, use get_cc().file() to
+    /// directly add a file to the build instead.
+    pub fn add_build_file<P: AsRef<Path>>(&mut self, file: P) {
+        add_build_file_with_rerun(self.get_cc(), file);
+    }
+
+    /// Add multiple files to the build. This also tags the files with cargo:rerun-if-changed so that cargo will re-run
+    /// the build script if the files change. If you don't want this additional behavior, use get_cc().files() to
+    /// directly add files to the build instead.
+    pub fn add_build_files<P>(&mut self, files: P)
+    where
+        P: IntoIterator,
+        P::Item: AsRef<Path>,
+    {
+        add_build_files_with_rerun(self.get_cc(), files);
+    }
+}
+
+fn add_build_file_with_rerun<P: AsRef<Path>>(build: &mut Build, file: P) {
+    build.file(&file);
+    println!("cargo:rerun-if-changed={}", file.as_ref().display());
+}
+
+fn add_build_files_with_rerun<P>(build: &mut Build, files: P)
+where
+    P: IntoIterator,
+    P::Item: AsRef<Path>,
+{
+    for file in files.into_iter() {
+        add_build_file_with_rerun(build, file);
+    }
+}
+
+fn add_include_with_rerun<P: AsRef<Path>>(build: &mut Build, dir: P) {
+    build.include(&dir);
+
+    WalkDir::new(&dir)
+        .follow_links(false)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .for_each(|entry| {
+            let f_name = entry.path();
+            if f_name.extension() == Some(OsStr::new("h")) {
+                println!("cargo:rerun-if-changed={}", f_name.display());
+            }
+        });
 }
 
 #[test]

--- a/freertos-rust-examples/build.rs
+++ b/freertos-rust-examples/build.rs
@@ -20,8 +20,8 @@ fn main() {
         b.freertos_config("examples/win");
         // TODO: in future all FreeRTOS API should be implemented by the freertos-rust crate
         // until then, we need to compile some C code manually
-        b.get_cc().file("examples/win/hooks.c");
-        b.get_cc().file("examples/win/Run-time-stats-utils.c");
+        b.add_build_file("examples/win/hooks.c");
+        b.add_build_file("examples/win/Run-time-stats-utils.c");
 
         if target_env == "msvc" {
             println!("cargo:rustc-link-lib=static=winmm");
@@ -31,8 +31,8 @@ fn main() {
     if target == "x86_64-unknown-linux-gnu" {
         b.freertos_config("examples/linux");
 
-        b.get_cc().file("examples/linux/hooks.c");
-        // b.get_cc().file("examples/linux/Run-time-stats-utils.c"); // Unimplemented yet..
+        b.add_build_file("examples/linux/hooks.c");
+        // b.add_build_file("examples/linux/Run-time-stats-utils.c"); // Unimplemented yet..
     }
 
     if target == "thumbv7m-none-eabi" {


### PR DESCRIPTION
#38

Also included H files, both for user's `FreeRTOSConfig.h` and FreeRTOS headers. Went back and forth on whether it's worth detecting changes to the FreeRTOS files since they shouldn't really be changing, but couldn't think of any downside and on the off chance someone is modifying those files locally this avoids confusion for them.

Also check for whether the custom env variables change since it's in the same spirit.

I made this behavior the default for the existing files/directories supplied by the user, and also gave them a pub fn for convenience for when they add their own files to the build (you can see this in the example `build.rs` for the win port).