### PR TITLE
Warning cleanup in project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   freertos-rust:
     name: Build freertos-rust
     runs-on: ubuntu-latest
-    #env:
-    #  RUSTFLAGS: -D warnings # Warnings disabled only in CI
+    env:
+      RUSTFLAGS: -D warnings # Warnings disabled only in CI
     steps:
     - name: Clone
       uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /.idea
+/.vscode
+Cargo.lock

--- a/freertos-rust-examples/Cargo.toml
+++ b/freertos-rust-examples/Cargo.toml
@@ -29,7 +29,7 @@ embedded-hal = "0.2.3"
 stm32f4xx-hal = {version = "0.8.3", features = ["rt", "stm32f411"]}
 
 # Example: nrf9160
-[target.thumbv8m.main-none-eabihf.dependencies]
+[target."thumbv8m.main-none-eabihf".dependencies]
 nrf9160-pac = "0.2.1"
 
 # Example: win

--- a/freertos-rust/src/utils.rs
+++ b/freertos-rust/src/utils.rs
@@ -4,9 +4,9 @@ use crate::shim::*;
 
 #[derive(Debug, Copy, Clone)]
 pub struct TypeSizeError {
-    id: usize,
-    c_size: usize,
-    rust_size: usize,
+    pub id: usize,
+    pub c_size: usize,
+    pub rust_size: usize,
 }
 
 #[cfg(feature = "cpu_clock")]


### PR DESCRIPTION
A few quick and easy warnings in the build to clean up.
* Unused struct members
* Unused manifest key for thumbv8m target (it was used, but due to the period in the name was being misinterpreted)

Since there's no warnings in the build, set the CI script to deny warnings in the project build (warnings in the examples haven't been fixed yet and so are not denied).

Also ignore `Cargo.lock` as this file shouldn't be committed for a library crate.