### PR TITLE
Allow non-RAII semaphore usage, fix semaphore guard lifetime issue

### DIFF
--- a/freertos-rust/src/semaphore.rs
+++ b/freertos-rust/src/semaphore.rs
@@ -47,9 +47,7 @@ impl Semaphore {
                 return Err(FreeRtosError::Timeout);
             }
 
-            Ok(SemaphoreGuard {
-                __semaphore: self.semaphore,
-            })
+            Ok(SemaphoreGuard { owner: self })
         }
     }
 }
@@ -63,14 +61,14 @@ impl Drop for Semaphore {
 }
 
 /// Holds the lock to the semaphore until we are dropped
-pub struct SemaphoreGuard {
-    __semaphore: FreeRtosSemaphoreHandle,
+pub struct SemaphoreGuard<'a> {
+    owner: &'a Semaphore,
 }
 
-impl Drop for SemaphoreGuard {
+impl<'a> Drop for SemaphoreGuard<'a> {
     fn drop(&mut self) {
         unsafe {
-            freertos_rs_give_mutex(self.__semaphore);
+            freertos_rs_give_mutex(self.owner.semaphore);
         }
     }
 }


### PR DESCRIPTION
1. `SemaphoreGuard` now borrows `Semaphore`. This ensures that guard will not outlive the semaphore itself.
2. Separate methods `give` and `take` added to semaphore. There is a use case for task synchronization where first task gives a semaphore while second one takes it.