### PR TITLE
Feature gate `allocator_api`

### DIFF
--- a/freertos-rust/src/lib.rs
+++ b/freertos-rust/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(allocator_api)]
+#![cfg_attr(feature = "allocator", feature(allocator_api))]
 //! # FreeRTOS for Rust
 //!
 //! Rust interface for the FreeRTOS embedded operating system. Requires nightly Rust.


### PR DESCRIPTION
Disable unstable feature `allocator_api` if crate feature `allocator` is disabled. This allows to use this crate with stable Rust.