### PR TITLE
Add test that stable toolchain builds if allocator is disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,27 @@ jobs:
     #  run: cargo test
     #- name: Clippy
     #  run: cargo clippy -- -Dwarnings
+  freertos-rust-stable:
+    name: Build freertos-rust using stable
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings # Warnings disabled only in CI
+    steps:
+    - name: Clone
+      uses: actions/checkout@v3
+    - name: Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          ~/.rustup
+          target
+        key: ${{ runner.os }}-${{ runner.arch }}-stable
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+    - name: Build
+      run: cargo build --verbose --no-default-features --features=sync,time,hooks,interrupt --package freertos-rust # Don't build the whole workspace because the examples use nightly features which will fail the build
   freertos-rust-examples:
     name: Build examples
     runs-on: ubuntu-latest

--- a/freertos-rust/src/lib.rs
+++ b/freertos-rust/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(feature = "allocator", feature(allocator_api))]
 //! # FreeRTOS for Rust
 //!
-//! Rust interface for the FreeRTOS embedded operating system. Requires nightly Rust.
+//! Rust interface for the FreeRTOS embedded operating system. Requires nightly Rust if the allocator is used (which is the default).
 //! It is assumed that dynamic memory allocation is provided on the target system.
 //!
 //! This library interfaces with FreeRTOS using a C shim library which provides function


### PR DESCRIPTION
Add test case to confirm that the stable toolchain continues to work when the allocator feature is disabled. Quick add-on to #47.