### PR TITLE
Fix build.rs in project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ info provided by your apps `build.rs`:
     freertos-cargo-build = "*"
     ```
     
-1. Add this snippet to your app's `build.rs`:
+1. Add this snippet to your apps `build.rs`:
     ```
     fn main() {
         let mut b = freertos_cargo_build::Builder::new();
@@ -47,9 +47,9 @@ info provided by your apps `build.rs`:
         // Path to FreeRTOS kernel or set ENV "FREERTOS_SRC" instead
         b.freertos("path/to/FreeRTOS-Kernel");
         b.freertos_config("src");       // Location of `FreeRTOSConfig.h` 
-        b.freertos_port("GCC/ARM_CM3".to_owned()); // Port dir relativ to 'FreeRTOS-Kernel/portable' 
-        b.heap::<String>(String::from("heap_4.c"));	// Set the heap_?.c allocator to use from 
-                                        			// 'FreeRTOS-Kernel/portable/MemMang' (Default: heap_4.c)       
+        b.freertos_port("GCC/ARM_CM3"); // Port dir relativ to 'FreeRTOS-Kernel/portable' 
+        b.heap("heap_4.c");             // Set the heap_?.c allocator to use from 
+                                        // 'FreeRTOS-Kernel/portable/MemMang' (Default: heap_4.c)       
    
         // b.get_cc().file("More.c");   // Optional additional C-Code to be compiled
     

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ info provided by your apps `build.rs`:
     freertos-cargo-build = "*"
     ```
     
-1. Add this snippet to your apps `build.rs`:
+1. Add this snippet to your app's `build.rs`:
     ```
     fn main() {
         let mut b = freertos_cargo_build::Builder::new();
@@ -47,13 +47,13 @@ info provided by your apps `build.rs`:
         // Path to FreeRTOS kernel or set ENV "FREERTOS_SRC" instead
         b.freertos("path/to/FreeRTOS-Kernel");
         b.freertos_config("src");       // Location of `FreeRTOSConfig.h` 
-        b.freertos_port("GCC/ARM_CM3"); // Port dir relativ to 'FreeRTOS-Kernel/portable' 
-        b.heap("heap4.c");              // Set the heap_?.c allocator to use from 
-                                        // 'FreeRTOS-Kernel/portable/MemMang' (Default: heap_4.c)       
+        b.freertos_port("GCC/ARM_CM3".to_owned()); // Port dir relativ to 'FreeRTOS-Kernel/portable' 
+        b.heap::<String>(String::from("heap_4.c"));	// Set the heap_?.c allocator to use from 
+                                        			// 'FreeRTOS-Kernel/portable/MemMang' (Default: heap_4.c)       
    
         // b.get_cc().file("More.c");   // Optional additional C-Code to be compiled
     
-        b.compile().unwrap_or_else(|e| { panic!(e.to_string()) });
+        b.compile().unwrap_or_else(|e| { panic!("{}", e.to_string()) });
     }
     ```   
 


### PR DESCRIPTION
This morning I've been experimenting with FreeRTOS-rust on an STM32F411RE Nucleo board. When setting up my project, I ran into some issues building the project when using the build.rs example provided in the readme. This PR fixes the issues I came across.

The errors I got:
```
error[E0308]: mismatched types                                                                                                                                                                                              
   --> build.rs:7:21
    |
7   |     b.freertos_port("GCC/ARM_CM3"); // Port dir relativ to 'FreeRTOS-Kernel/portable' 
    |       ------------- ^^^^^^^^^^^^^- help: try using a conversion method: `.to_string()`
    |       |             |
    |       |             expected `String`, found `&str`
    |       arguments to this method are incorrect
    |
``` 
was fixed by adding .to_owned().
```
   --> build.rs:8:12
    |
8   |     b.heap("heap4.c");              // Set the heap_?.c allocator to use from
    |       ---- ^^^^^^^^^- help: try using a conversion method: `.to_string()`
    |       |    |
    |       |    expected `String`, found `&str`
    |       arguments to this method are incorrect
    |
```
was fixed by creating a String from the string literal. After doing this, I got:
```
error[E0282]: type annotations needed
 --> build.rs:8:7
  |
8 |     b.heap(String::from("heap4.c"));              // Set the heap_?.c allocator to use from
  |       ^^^^ cannot infer type of the type parameter `P` declared on the associated function `heap`
  |
help: consider specifying the generic argument
  |
8 |     b.heap::<P>(String::from("heap4.c"));              // Set the heap_?.c allocator to use from
  |           +++++
```
which was solved by `b.heap::<String>(......`

```
error: format argument must be a string literal
  --> build.rs:13:45
   |
13 |     b.compile().unwrap_or_else(|e| { panic!(e.to_string()) });
   |                                             ^^^^^^^^^^^^^
   |
help: you might be missing a string literal to format with
   |
13 |     b.compile().unwrap_or_else(|e| { panic!("{}", e.to_string()) });
   |                                             +++++
```

I'll try to create a PR for an example of FreeRTOS-rust on the STM32F411 Nucleo board later today.
Thanks everyone for this project.
