### PR TITLE
Allow not to use `vTaskDelete()`

### DIFF
--- a/freertos-rust/Cargo.toml
+++ b/freertos-rust/Cargo.toml
@@ -18,10 +18,11 @@ name = "freertos_rust"
 path = "src/lib.rs"
 
 [features]
-default = ["allocator", "sync", "time", "hooks", "interrupt"]
+default = ["allocator", "sync", "time", "hooks", "interrupt", "delete_task"]
 allocator = []
 sync = ["interrupt"]
 time = ["interrupt"]
 hooks = []
 interrupt = []
 cpu_clock = []
+delete_task = []

--- a/freertos-rust/src/task.rs
+++ b/freertos-rust/src/task.rs
@@ -164,10 +164,14 @@ impl Task {
                     });
                 }
 
+                #[cfg(feature = "delete_task")]
                 freertos_rs_delete_task(0 as *const _);
             }
 
-            0 as *mut _
+            #[cfg(feature = "delete_task")]
+            return 0 as *mut _;
+            #[cfg(not(feature = "delete_task"))]
+            panic!("Not allowed to quit the task!");
         }
 
         Ok(Task {


### PR DESCRIPTION
Currently, if `INCLUDE_vTaskDelete` is set to 0, the compilation will fail.
```
rust-lld: error: undefined symbol: freertos_rs_delete_task
>>> referenced by task.rs:167 (src\task.rs:167)
```