### PR TITLE
Add methods to use semaphore from ISR

### DIFF
--- a/freertos-rust/src/semaphore.rs
+++ b/freertos-rust/src/semaphore.rs
@@ -1,4 +1,5 @@
 use crate::base::*;
+use crate::isr::*;
 use crate::shim::*;
 use crate::units::*;
 
@@ -58,6 +59,16 @@ impl Semaphore {
 
             Ok(())
         }
+    }
+
+    /// Returns `true` on success, `false` when semaphore count already reached its limit
+    pub fn give_from_isr(&self, context: &mut InterruptContext) -> bool {
+        unsafe { freertos_rs_give_semaphore_isr(self.semaphore, context.get_task_field_mut()) == 0 }
+    }
+
+    /// Returns `true` on success, `false` if the semaphore was not successfully taken because it was not available
+    pub fn take_from_isr(&self, context: &mut InterruptContext) -> bool {
+        unsafe { freertos_rs_take_semaphore_isr(self.semaphore, context.get_task_field_mut()) == 0 }
     }
 }
 

--- a/freertos-rust/src/shim.rs
+++ b/freertos-rust/src/shim.rs
@@ -38,6 +38,15 @@ extern "C" {
     pub fn freertos_rs_give_mutex(mutex: FreeRtosQueueHandle) -> FreeRtosBaseType;
     pub fn freertos_rs_give_recursive_mutex(mutex: FreeRtosQueueHandle) -> FreeRtosBaseType;
 
+    pub fn freertos_rs_take_semaphore_isr(
+        semaphore: FreeRtosQueueHandle,
+        xHigherPriorityTaskWoken: FreeRtosBaseTypeMutPtr,
+    ) -> FreeRtosBaseType;
+    pub fn freertos_rs_give_semaphore_isr(
+        semaphore: FreeRtosQueueHandle,
+        xHigherPriorityTaskWoken: FreeRtosBaseTypeMutPtr,
+    ) -> FreeRtosBaseType;
+
     pub fn freertos_rs_delete_semaphore(mutex: FreeRtosQueueHandle);
 
     pub fn freertos_rs_create_binary_semaphore() -> FreeRtosQueueHandle;


### PR DESCRIPTION
There already are [shim functions for that](https://github.com/lobaro/FreeRTOS-rust/blob/master/freertos-rust/src/freertos/shim.c#L183-L197), but they were not used in Rust library.