### PR TITLE
Fix `task_handle` type mismatch on task spawn

### DIFF
--- a/freertos-rust/src/base.rs
+++ b/freertos-rust/src/base.rs
@@ -32,7 +32,6 @@ pub type FreeRtosTickType = u32;
 pub type FreeRtosBaseTypeMutPtr = *mut FreeRtosBaseType;
 
 pub type FreeRtosTaskHandle = *const CVoid;
-pub type FreeRtosMutTaskHandle = *mut CVoid;
 pub type FreeRtosQueueHandle = *const CVoid;
 pub type FreeRtosSemaphoreHandle = *const CVoid;
 pub type FreeRtosTaskFunction = *const CVoid;

--- a/freertos-rust/src/shim.rs
+++ b/freertos-rust/src/shim.rs
@@ -99,7 +99,7 @@ extern "C" {
         name_len: u8,
         stack_size: u16,
         priority: FreeRtosUBaseType,
-        task_handle: FreeRtosMutTaskHandle,
+        task_handle: *mut FreeRtosTaskHandle,
     ) -> FreeRtosUBaseType;
     pub fn freertos_rs_delete_task(task: FreeRtosTaskHandle);
     pub fn freertos_rs_suspend_task(task: FreeRtosTaskHandle);

--- a/freertos-rust/src/task.rs
+++ b/freertos-rust/src/task.rs
@@ -134,7 +134,7 @@ impl Task {
         let (success, task_handle) = {
             let name = name.as_bytes();
             let name_len = name.len();
-            let mut task_handle = mem::zeroed::<CVoid>();
+            let mut task_handle = core::ptr::null();
 
             let ret = freertos_rs_spawn_task(
                 thread_start,
@@ -174,9 +174,7 @@ impl Task {
             panic!("Not allowed to quit the task!");
         }
 
-        Ok(Task {
-            task_handle: task_handle as usize as *const _,
-        })
+        Ok(Task { task_handle })
     }
 
     fn spawn<F>(


### PR DESCRIPTION
`freertos_rs_spawn_task` from [`shim.c`](https://github.com/lobaro/FreeRTOS-rust/blob/698a1f1fe4bf37074d3f296a888f72897f578896/freertos-rust/src/freertos/shim.c#L200) (as well as [`xTaskCreate`](https://www.freertos.org/a00125.html)) takes `TaskHandle_t *` as last argument.

But in [`shim.rs`](https://github.com/lobaro/FreeRTOS-rust/blob/698a1f1fe4bf37074d3f296a888f72897f578896/freertos-rust/src/shim.rs#L95-L103) this function takes [`FreeRtosMutTaskHandle`](https://github.com/lobaro/FreeRTOS-rust/blob/698a1f1fe4bf37074d3f296a888f72897f578896/freertos-rust/src/base.rs#L35) (`*mut CVoid`) which is not the same as `*mut FreeRtosTaskHandle` (`*mut *const CVoid`).

So `xTaskCreate` tries to store `TaskHandle_t` into `CVoid`, but they may have different size and alignment.

This PR fixes this issue.