### PR TITLE
Rename semaphore and mutex shim functions according to FreeRTOS API

### DIFF
--- a/freertos-rust/src/freertos/shim.c
+++ b/freertos-rust/src/freertos/shim.c
@@ -128,19 +128,19 @@ UBaseType_t freertos_rs_get_number_of_tasks() {
 }
 
 #if (configUSE_RECURSIVE_MUTEXES == 1)
-QueueHandle_t freertos_rs_create_recursive_mutex() {
+SemaphoreHandle_t freertos_rs_create_recursive_mutex() {
 	return xSemaphoreCreateRecursiveMutex();
 }
 
-UBaseType_t freertos_rs_take_recursive_mutex(QueueHandle_t mutex, UBaseType_t max) {
-	if (xSemaphoreTakeRecursive(mutex, max) == pdTRUE) {
+UBaseType_t freertos_rs_take_recursive_semaphore(SemaphoreHandle_t semaphore, UBaseType_t max) {
+	if (xSemaphoreTakeRecursive(semaphore, max) == pdTRUE) {
 		return 0;
 	}
 
 	return 1;
 }
-UBaseType_t freertos_rs_give_recursive_mutex(QueueHandle_t mutex) {
-	if (xSemaphoreGiveRecursive(mutex) == pdTRUE) {
+UBaseType_t freertos_rs_give_recursive_semaphore(SemaphoreHandle_t semaphore) {
+	if (xSemaphoreGiveRecursive(semaphore) == pdTRUE) {
 		return 0;
 	} else {
 		return 1;
@@ -148,39 +148,39 @@ UBaseType_t freertos_rs_give_recursive_mutex(QueueHandle_t mutex) {
 }
 #endif
 
-QueueHandle_t freertos_rs_create_mutex() {
+SemaphoreHandle_t freertos_rs_create_mutex() {
 	return xSemaphoreCreateMutex();
 }
 
-QueueHandle_t freertos_rs_create_binary_semaphore() {
+SemaphoreHandle_t freertos_rs_create_binary_semaphore() {
 	return xSemaphoreCreateBinary();
 }
 
-QueueHandle_t freertos_rs_create_counting_semaphore(UBaseType_t max, UBaseType_t initial) {
+SemaphoreHandle_t freertos_rs_create_counting_semaphore(UBaseType_t max, UBaseType_t initial) {
 	return xSemaphoreCreateCounting(max, initial);
 }
 
-void freertos_rs_delete_semaphore(QueueHandle_t semaphore) {
+void freertos_rs_delete_semaphore(SemaphoreHandle_t semaphore) {
 	vSemaphoreDelete(semaphore);
 }
 
-UBaseType_t freertos_rs_take_mutex(QueueHandle_t mutex, UBaseType_t max) {
-	if (xSemaphoreTake(mutex, max) == pdTRUE) {
+UBaseType_t freertos_rs_take_semaphore(SemaphoreHandle_t semaphore, UBaseType_t max) {
+	if (xSemaphoreTake(semaphore, max) == pdTRUE) {
 		return 0;
 	}
 
 	return 1;
 }
 
-UBaseType_t freertos_rs_give_mutex(QueueHandle_t mutex) {
-	if (xSemaphoreGive(mutex) == pdTRUE) {
+UBaseType_t freertos_rs_give_semaphore(SemaphoreHandle_t semaphore) {
+	if (xSemaphoreGive(semaphore) == pdTRUE) {
 		return 0;
 	}
 
 	return 1;
 }
 
-UBaseType_t freertos_rs_take_semaphore_isr(QueueHandle_t semaphore, BaseType_t* xHigherPriorityTaskWoken) {
+UBaseType_t freertos_rs_take_semaphore_isr(SemaphoreHandle_t semaphore, BaseType_t* xHigherPriorityTaskWoken) {
 	if (xSemaphoreTakeFromISR(semaphore, xHigherPriorityTaskWoken) == pdTRUE) {
 		return 0;
 	}
@@ -188,7 +188,7 @@ UBaseType_t freertos_rs_take_semaphore_isr(QueueHandle_t semaphore, BaseType_t* 
 	return 1;
 }
 
-UBaseType_t freertos_rs_give_semaphore_isr(QueueHandle_t semaphore, BaseType_t* xHigherPriorityTaskWoken) {
+UBaseType_t freertos_rs_give_semaphore_isr(SemaphoreHandle_t semaphore, BaseType_t* xHigherPriorityTaskWoken) {
 	if (xSemaphoreGiveFromISR(semaphore, xHigherPriorityTaskWoken) == pdTRUE) {
 		return 0;
 	}

--- a/freertos-rust/src/mutex.rs
+++ b/freertos-rust/src/mutex.rs
@@ -140,7 +140,7 @@ impl MutexInnerImpl for MutexNormal {
     }
 
     fn take<D: DurationTicks>(&self, max_wait: D) -> Result<(), FreeRtosError> {
-        let res = unsafe { freertos_rs_take_mutex(self.0, max_wait.to_ticks()) };
+        let res = unsafe { freertos_rs_take_semaphore(self.0, max_wait.to_ticks()) };
 
         if res != 0 {
             return Err(FreeRtosError::MutexTimeout);
@@ -151,7 +151,7 @@ impl MutexInnerImpl for MutexNormal {
 
     fn give(&self) {
         unsafe {
-            freertos_rs_give_mutex(self.0);
+            freertos_rs_give_semaphore(self.0);
         }
     }
 }
@@ -180,7 +180,7 @@ impl MutexInnerImpl for MutexRecursive {
     }
 
     fn take<D: DurationTicks>(&self, max_wait: D) -> Result<(), FreeRtosError> {
-        let res = unsafe { freertos_rs_take_recursive_mutex(self.0, max_wait.to_ticks()) };
+        let res = unsafe { freertos_rs_take_recursive_semaphore(self.0, max_wait.to_ticks()) };
 
         if res != 0 {
             return Err(FreeRtosError::MutexTimeout);
@@ -191,7 +191,7 @@ impl MutexInnerImpl for MutexRecursive {
 
     fn give(&self) {
         unsafe {
-            freertos_rs_give_recursive_mutex(self.0);
+            freertos_rs_give_recursive_semaphore(self.0);
         }
     }
 }

--- a/freertos-rust/src/semaphore.rs
+++ b/freertos-rust/src/semaphore.rs
@@ -46,12 +46,12 @@ impl Semaphore {
 
     /// Returns `true` on success, `false` when semaphore count already reached its limit
     pub fn give(&self) -> bool {
-        unsafe { freertos_rs_give_mutex(self.semaphore) == 0 }
+        unsafe { freertos_rs_give_semaphore(self.semaphore) == 0 }
     }
 
     pub fn take<D: DurationTicks>(&self, max_wait: D) -> Result<(), FreeRtosError> {
         unsafe {
-            let res = freertos_rs_take_mutex(self.semaphore, max_wait.to_ticks());
+            let res = freertos_rs_take_semaphore(self.semaphore, max_wait.to_ticks());
 
             if res != 0 {
                 return Err(FreeRtosError::Timeout);

--- a/freertos-rust/src/shim.rs
+++ b/freertos-rust/src/shim.rs
@@ -24,36 +24,38 @@ extern "C" {
 
     pub fn freertos_rs_xTaskGetTickCount() -> FreeRtosTickType;
 
-    pub fn freertos_rs_create_recursive_mutex() -> FreeRtosQueueHandle;
-    pub fn freertos_rs_create_mutex() -> FreeRtosQueueHandle;
+    pub fn freertos_rs_create_recursive_mutex() -> FreeRtosSemaphoreHandle;
+    pub fn freertos_rs_create_mutex() -> FreeRtosSemaphoreHandle;
 
-    pub fn freertos_rs_take_recursive_mutex(
-        mutex: FreeRtosQueueHandle,
+    pub fn freertos_rs_take_recursive_semaphore(
+        semaphore: FreeRtosSemaphoreHandle,
         max: FreeRtosTickType,
     ) -> FreeRtosBaseType;
-    pub fn freertos_rs_take_mutex(
-        mutex: FreeRtosQueueHandle,
+    pub fn freertos_rs_take_semaphore(
+        semaphore: FreeRtosSemaphoreHandle,
         max: FreeRtosTickType,
     ) -> FreeRtosBaseType;
-    pub fn freertos_rs_give_mutex(mutex: FreeRtosQueueHandle) -> FreeRtosBaseType;
-    pub fn freertos_rs_give_recursive_mutex(mutex: FreeRtosQueueHandle) -> FreeRtosBaseType;
+    pub fn freertos_rs_give_semaphore(semaphore: FreeRtosSemaphoreHandle) -> FreeRtosBaseType;
+    pub fn freertos_rs_give_recursive_semaphore(
+        semaphore: FreeRtosSemaphoreHandle,
+    ) -> FreeRtosBaseType;
 
     pub fn freertos_rs_take_semaphore_isr(
-        semaphore: FreeRtosQueueHandle,
+        semaphore: FreeRtosSemaphoreHandle,
         xHigherPriorityTaskWoken: FreeRtosBaseTypeMutPtr,
     ) -> FreeRtosBaseType;
     pub fn freertos_rs_give_semaphore_isr(
-        semaphore: FreeRtosQueueHandle,
+        semaphore: FreeRtosSemaphoreHandle,
         xHigherPriorityTaskWoken: FreeRtosBaseTypeMutPtr,
     ) -> FreeRtosBaseType;
 
-    pub fn freertos_rs_delete_semaphore(mutex: FreeRtosQueueHandle);
+    pub fn freertos_rs_delete_semaphore(semaphore: FreeRtosSemaphoreHandle);
 
-    pub fn freertos_rs_create_binary_semaphore() -> FreeRtosQueueHandle;
+    pub fn freertos_rs_create_binary_semaphore() -> FreeRtosSemaphoreHandle;
     pub fn freertos_rs_create_counting_semaphore(
         max: FreeRtosUBaseType,
         initial: FreeRtosUBaseType,
-    ) -> FreeRtosQueueHandle;
+    ) -> FreeRtosSemaphoreHandle;
 
     pub fn freertos_rs_queue_create(
         length: FreeRtosUBaseType,


### PR DESCRIPTION
Shim functions related to semaphores and mutexes affected:
+ Changed function postfixes from `*_mutex` to `*_semaphore` (except mutex creation functions) to match FreeRTOS API names.
+ Changed types from `QueueHandle_t` to `SemaphoreHandle_t` and from `FreeRtosQueueHandle` to `FreeRtosSemaphoreHandle`.
+ Renamed arguments from `mutex` to `semaphore`.