### PR TITLE
Conversion from/to raw handle

### DIFF
--- a/freertos-rust/src/isr.rs
+++ b/freertos-rust/src/isr.rs
@@ -17,7 +17,7 @@ impl InterruptContext {
         }
     }
 
-    pub unsafe fn get_task_field_mut(&self) -> FreeRtosBaseTypeMutPtr {
+    pub fn get_task_field_mut(&self) -> FreeRtosBaseTypeMutPtr {
         self.x_higher_priority_task_woken as *mut _
     }
 }

--- a/freertos-rust/src/mutex.rs
+++ b/freertos-rust/src/mutex.rs
@@ -62,22 +62,7 @@ where
 
     /// Consume the mutex and return its inner value
     pub fn into_inner(self) -> T {
-        // Manually deconstruct the structure, because it implements Drop
-        // and we cannot move the data value out of it.
-        unsafe {
-            let (mutex, data) = {
-                let Self {
-                    ref mutex,
-                    ref data,
-                } = self;
-                (ptr::read(mutex), ptr::read(data))
-            };
-            mem::forget(self);
-
-            drop(mutex);
-
-            data.into_inner()
-        }
+        self.data.into_inner()
     }
 }
 

--- a/freertos-rust/src/mutex.rs
+++ b/freertos-rust/src/mutex.rs
@@ -126,6 +126,8 @@ where
 
     /// # Safety
     ///
+    /// `handle` must be a valid FreeRTOS mutex handle.
+    ///
     /// The type of `handle` (normal or recursive mutex) must match the type
     /// of instance being created ([`MutexNormal`] or [`MutexRecursive`] respectively).
     unsafe fn from_raw_handle(handle: FreeRtosSemaphoreHandle) -> Self;

--- a/freertos-rust/src/mutex.rs
+++ b/freertos-rust/src/mutex.rs
@@ -124,6 +124,10 @@ where
     fn take<D: DurationTicks>(&self, max_wait: D) -> Result<(), FreeRtosError>;
     fn give(&self);
 
+    /// # Safety
+    ///
+    /// The type of `handle` (normal or recursive mutex) must match the type
+    /// of instance being created ([`MutexNormal`] or [`MutexRecursive`] respectively).
     unsafe fn from_raw_handle(handle: FreeRtosSemaphoreHandle) -> Self;
     fn raw_handle(&self) -> FreeRtosSemaphoreHandle;
 }

--- a/freertos-rust/src/queue.rs
+++ b/freertos-rust/src/queue.rs
@@ -38,6 +38,10 @@ impl<T: Sized + Copy> Queue<T> {
             item_type: PhantomData,
         }
     }
+    #[inline]
+    pub fn raw_handle(&self) -> FreeRtosQueueHandle {
+        self.queue
+    }
 
     /// Send an item to the end of the queue. Wait for the queue to have empty space for it.
     pub fn send<D: DurationTicks>(&self, item: T, max_wait: D) -> Result<(), FreeRtosError> {

--- a/freertos-rust/src/queue.rs
+++ b/freertos-rust/src/queue.rs
@@ -31,6 +31,11 @@ impl<T: Sized + Copy> Queue<T> {
         })
     }
 
+    /// # Safety
+    ///
+    /// `handle` must be a valid FreeRTOS regular queue handle (not semaphore or mutex).
+    ///
+    /// The item size of the queue must match the size of `T`.
     #[inline]
     pub unsafe fn from_raw_handle(handle: FreeRtosQueueHandle) -> Self {
         Self {

--- a/freertos-rust/src/semaphore.rs
+++ b/freertos-rust/src/semaphore.rs
@@ -34,6 +34,12 @@ impl Semaphore {
         }
     }
 
+    /// # Safety
+    ///
+    /// `handle` must be a valid FreeRTOS semaphore handle.
+    ///
+    /// Only binary or counting semaphore is expected here.
+    /// To create mutex from raw handle use [`crate::mutex::MutexInnerImpl::from_raw_handle`].
     #[inline]
     pub unsafe fn from_raw_handle(handle: FreeRtosSemaphoreHandle) -> Self {
         Self { semaphore: handle }

--- a/freertos-rust/src/semaphore.rs
+++ b/freertos-rust/src/semaphore.rs
@@ -38,6 +38,10 @@ impl Semaphore {
     pub unsafe fn from_raw_handle(handle: FreeRtosSemaphoreHandle) -> Self {
         Self { semaphore: handle }
     }
+    #[inline]
+    pub fn raw_handle(&self) -> FreeRtosSemaphoreHandle {
+        self.semaphore
+    }
 
     /// Lock this semaphore in a RAII fashion
     pub fn lock<D: DurationTicks>(&self, max_wait: D) -> Result<SemaphoreGuard, FreeRtosError> {

--- a/freertos-rust/src/task.rs
+++ b/freertos-rust/src/task.rs
@@ -105,6 +105,9 @@ impl Task {
         }
     }
 
+    /// # Safety
+    ///
+    /// `handle` must be a valid FreeRTOS task handle.
     #[inline]
     pub unsafe fn from_raw_handle(handle: FreeRtosTaskHandle) -> Self {
         Self { task_handle: handle }

--- a/freertos-rust/src/task.rs
+++ b/freertos-rust/src/task.rs
@@ -109,6 +109,10 @@ impl Task {
     pub unsafe fn from_raw_handle(handle: FreeRtosTaskHandle) -> Self {
         Self { task_handle: handle }
     }
+    #[inline]
+    pub fn raw_handle(&self) -> FreeRtosTaskHandle {
+        self.task_handle
+    }
 
     pub fn suspend_all() {
       unsafe {

--- a/freertos-rust/src/timers.rs
+++ b/freertos-rust/src/timers.rs
@@ -70,6 +70,11 @@ impl Timer {
     }
 
     /// Create a timer from a raw handle.
+    ///
+    /// # Safety
+    ///
+    /// `handle` must be a valid FreeRTOS timer handle.
+    #[inline]
     pub unsafe fn from_raw_handle(handle: FreeRtosTimerHandle) -> Self {
         Self { handle }
     }

--- a/freertos-rust/src/timers.rs
+++ b/freertos-rust/src/timers.rs
@@ -14,7 +14,6 @@ unsafe impl Sync for Timer {}
 /// for that queue to get unblocked.
 pub struct Timer {
     handle: FreeRtosTimerHandle,
-    detached: bool,
 }
 
 /// Helper builder for a new software timer.
@@ -72,7 +71,7 @@ impl Timer {
 
     /// Create a timer from a raw handle.
     pub unsafe fn from_raw_handle(handle: FreeRtosTimerHandle) -> Self {
-        Self { handle, detached: false }
+        Self { handle }
     }
     #[inline]
     pub fn raw_handle(&self) -> FreeRtosTimerHandle {
@@ -113,10 +112,7 @@ impl Timer {
         extern "C" fn timer_callback(handle: FreeRtosTimerHandle) -> () {
             unsafe {
                 {
-                    let timer = Timer {
-                        handle: handle,
-                        detached: true,
-                    };
+                    let timer = Timer { handle };
                     if let Ok(callback_ptr) = timer.get_id() {
                         let b = Box::from_raw(callback_ptr as *mut Box<dyn Fn(Timer)>);
                         b(timer);
@@ -128,7 +124,6 @@ impl Timer {
 
         Ok(Timer {
             handle: timer_handle as *const _,
-            detached: false,
         })
     }
 
@@ -202,8 +197,10 @@ impl Timer {
     /// will consume the memory.
     ///
     /// Can be used for timers that will never be changed and don't need to stay in scope.
-    pub unsafe fn detach(mut self) {
-        self.detached = true;
+    ///
+    /// This method is safe because resource leak is safe in Rust.
+    pub fn detach(self) {
+        mem::forget(self);
     }
 
     fn get_id(&self) -> Result<FreeRtosVoidPtr, FreeRtosError> {
@@ -214,10 +211,6 @@ impl Timer {
 impl Drop for Timer {
     #[allow(unused_must_use)]
     fn drop(&mut self) {
-        if self.detached == true {
-            return;
-        }
-
         unsafe {
             if let Ok(callback_ptr) = self.get_id() {
                 // free the memory

--- a/freertos-rust/src/timers.rs
+++ b/freertos-rust/src/timers.rs
@@ -74,6 +74,10 @@ impl Timer {
     pub unsafe fn from_raw_handle(handle: FreeRtosTimerHandle) -> Self {
         Self { handle, detached: false }
     }
+    #[inline]
+    pub fn raw_handle(&self) -> FreeRtosTimerHandle {
+        self.handle
+    }
 
     unsafe fn spawn_inner<'a>(
         name: &str,

--- a/freertos-rust/src/utils.rs
+++ b/freertos-rust/src/utils.rs
@@ -50,6 +50,9 @@ pub fn shim_sanity_check() -> Result<(), TypeSizeError> {
     Ok(())
 }
 
+/// # Safety
+///
+/// `str` must be a pointer to the beginning of nul-terminated sequence of bytes.
 #[cfg(any(feature = "time", feature = "hooks", feature = "sync"))]
 pub unsafe fn str_from_c_string(str: *const u8) -> Result<String, FreeRtosError> {
     let mut buf = Vec::new();


### PR DESCRIPTION
+ For `Semaphore`, `Task` and `Timer`: added method to get raw handle (`raw_handle`).
+ For `Mutex`:
  + Added methods to convert from/to inner parts and to get mutable access to them.
  + Added `from_raw_handle` and `raw_handle` to non-owning mutexes (`MutexInnerImpl`).