### PR TITLE
Adding STM32F3Discovery port as a community port

### DIFF
--- a/community-ports.md
+++ b/community-ports.md
@@ -1,0 +1,5 @@
+This is a list of ports added by the community
+
+* Board: STM32F3DISCOVERY
+  CPU: STM32F303VC
+  URL: https://github.com/sheref-sidarous/stm32f3discovery_freertos_rust


### PR DESCRIPTION
I decided to run FreeRTOS-rust on STM32F3Discovery, and would like to share my work. This board is the one recommended by [The Rust Embedded book](https://docs.rust-embedded.org/book/intro/hardware.html) so I hope this port will be useful to other aspiring Embedded Rust programmers.

But I don't advocate that the port should be added to the examples, therefore I propose starting a "Community Ports" list.