### PR TITLE
Fixed shim complilation issues

### DIFF
--- a/freertos-rust/src/freertos/shim.c
+++ b/freertos-rust/src/freertos/shim.c
@@ -234,6 +234,7 @@ UBaseType_t freertos_rs_get_stack_high_water_mark(TaskHandle_t task) {
 #if (INCLUDE_uxTaskGetStackHighWaterMark == 1)
 	return uxTaskGetStackHighWaterMark(task);
 #else
+	(void)task;
 	return 0;
 #endif
 }

--- a/freertos-rust/src/freertos/shim.c
+++ b/freertos-rust/src/freertos/shim.c
@@ -109,9 +109,11 @@ TickType_t freertos_rs_xTaskGetTickCount() {
 	return xTaskGetTickCount();
 }
 
+#if (configUSE_TRACE_FACILITY == 1)
 UBaseType_t freertos_rs_get_system_state(TaskStatus_t * const pxTaskStatusArray, const UBaseType_t uxArraySize, uint32_t * const pulTotalRunTime) {
 	return uxTaskGetSystemState(pxTaskStatusArray, uxArraySize, pulTotalRunTime);
 }
+#endif
 
 #ifdef configCPU_CLOCK_HZ
 unsigned long freertos_rs_get_configCPU_CLOCK_HZ() {


### PR DESCRIPTION
Make freertos_rs_get_system_state() optional with #if guard. uxTaskGetSystemState() is only available when configUSE_TRACE_FACILITY is enabled.

Suppress unused parameter warning when INCLUDE_uxTaskGetStackHighWaterMark is disabled.