### PR TITLE
Remove unused imports

### DIFF
--- a/freertos-rust/src/prelude/no_std.rs
+++ b/freertos-rust/src/prelude/no_std.rs
@@ -1,19 +1,12 @@
-pub use core::cell::RefCell;
 pub use core::cell::UnsafeCell;
 pub use core::cmp::*;
 pub use core::fmt;
-pub use core::intrinsics::write_bytes;
 pub use core::iter::Iterator;
 pub use core::marker::PhantomData;
 pub use core::mem;
-pub use core::num::Wrapping;
-pub use core::ops::Range;
 pub use core::ops::{Deref, DerefMut};
-pub use core::prelude::*;
-pub use core::ptr;
 
 pub use alloc::boxed::Box;
-pub use alloc::rc::Rc;
 pub use alloc::string::*;
 pub use alloc::sync::{Arc, Weak};
 pub use alloc::vec::Vec;


### PR DESCRIPTION
This fixes all warnings and should let the project build clean again.