### PR TITLE
Remove redundant import

### DIFF
--- a/freertos-rust/src/prelude/no_std.rs
+++ b/freertos-rust/src/prelude/no_std.rs
@@ -1,7 +1,6 @@
 pub use core::cell::UnsafeCell;
 pub use core::cmp::*;
 pub use core::fmt;
-pub use core::iter::Iterator;
 pub use core::marker::PhantomData;
 pub use core::mem;
 pub use core::ops::{Deref, DerefMut};


### PR DESCRIPTION
Nightly has a new lint (or additions to an existing one) that detects redundant imports. It seems we import `Iterator` but it's already in the Rust prelude.
Unclear if this lint will persist (see https://github.com/rust-lang/rust/issues/121708) but seems reasonable to accommodate anyway.