### PR TITLE
Fix interpreting `x_higher_priority_task_woken` value as a pointer

### DIFF
--- a/freertos-rust/src/isr.rs
+++ b/freertos-rust/src/isr.rs
@@ -17,8 +17,11 @@ impl InterruptContext {
         }
     }
 
-    pub fn get_task_field_mut(&self) -> FreeRtosBaseTypeMutPtr {
-        self.x_higher_priority_task_woken as *mut _
+    pub fn get_task_field_mut(&mut self) -> FreeRtosBaseTypeMutPtr {
+        &mut self.x_higher_priority_task_woken as *mut _
+    }
+    pub fn higher_priority_task_woken(&self) -> FreeRtosBaseType {
+        self.x_higher_priority_task_woken
     }
 }
 

--- a/freertos-rust/src/task.rs
+++ b/freertos-rust/src/task.rs
@@ -241,7 +241,7 @@ impl Task {
     /// Notify this task from an interrupt.
     pub fn notify_from_isr(
         &self,
-        context: &InterruptContext,
+        context: &mut InterruptContext,
         notification: TaskNotification,
     ) -> Result<(), FreeRtosError> {
         unsafe {

--- a/freertos-rust/src/timers.rs
+++ b/freertos-rust/src/timers.rs
@@ -157,7 +157,7 @@ impl Timer {
     }
 
     /// Start the timer from an interrupt.
-    pub fn start_from_isr(&self, context: &InterruptContext) -> Result<(), FreeRtosError> {
+    pub fn start_from_isr(&self, context: &mut InterruptContext) -> Result<(), FreeRtosError> {
         unsafe {
             if freertos_rs_timer_start_from_isr(self.handle, context.get_task_field_mut()) == 0 {
                 Ok(())


### PR DESCRIPTION
Also:
+ Require `InterruptContext` to be mutable to avoid introducing interior mutability.
+ Add `higher_priority_task_woken` method to it to have a way to check the flag value.