### PR TITLE
Fix build warning due to unused return value

### DIFF
--- a/freertos-rust/src/timers.rs
+++ b/freertos-rust/src/timers.rs
@@ -121,7 +121,7 @@ impl Timer {
                     if let Ok(callback_ptr) = timer.get_id() {
                         let b = Box::from_raw(callback_ptr as *mut Box<dyn Fn(Timer)>);
                         b(timer);
-                        Box::into_raw(b);
+                        let _ = Box::into_raw(b);
                     }
                 }
             }


### PR DESCRIPTION
```
error: unused return value of `alloc::boxed::Box::<T, A>::into_raw` that must be used
   --> freertos-rust/src/timers.rs:124:25
    |
124 |                         Box::into_raw(b);
    |                         ^^^^^^^^^^^^^^^^
    |
    = note: losing the pointer will leak memory
    = note: `-D unused-must-use` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_must_use)]`
help: use `let _ = ...` to ignore the resulting value
    |
124 |                         let _ = Box::into_raw(b);
    |                         +++++++
```