### PR TITLE
Updated FreeRTOS-Rust Linux setup instruction information in README doc

### DIFF
--- a/freertos-rust-examples/README.md
+++ b/freertos-rust-examples/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-We need to use nightly toolchain to support all examples. 
+We need to use nightly toolchain to support all examples.
 Even if some might run with the stable toolchain as well.
 
 **GNU Toolchain** is required for debugging some examples (e.g. windows):
@@ -46,7 +46,7 @@ To see all errors use:
 
 ### Run Windows Demo
 
-You need to build with nightly GNU to allow debugging. 
+You need to build with nightly GNU to allow debugging.
 The target must be `x86_64-pc-windows-msvc` for the FreeRTOS `MSVC-MingW` port.
 
 Prepare the build with:
@@ -60,13 +60,21 @@ Run the build
 
 ### Run Linux Demo
 
-
 Prepare the build with:
 
-    rustup default x86_64-unknown-linux-gnu
+    rustup default nightly
+    rustup toolchain install nightly
     rustup target add x86_64-unknown-linux-gnu
-
+    rustup component add llvm-tools-preview
+    cargo install cargo-binutils
+    
+    sudo apt install gcc g++ make
+    
 Run the build
+
+    cargo build --package freertos-rust-examples --example linux --target x86_64-unknown-linux-gnu
+
+Run the example
 
     cargo run --package freertos-rust-examples --example linux --target x86_64-unknown-linux-gnu
 
@@ -126,21 +134,21 @@ Create the Toolchain under: `File | Settings | Build, Execution, Deployment | To
 * Name: `arm-none-eabi`
 * Debugger: `/path/to/arm-none-eabi-gdb.exe`
 
-Build: 
+Build:
 
 * Name: `build-nrf9160-example`
 * Programm: `cargo`
 * Arguments: `build --package freertos-rust-examples --example nrf9160 --target thumbv8m.main-none-eabihf`
 * Working directory: `$ProjectFileDir$`
 
-Clean: 
+Clean:
 
 * Name: `clean`
 * Programm: `cargo`
 * Arguments: `clean`
 * Working directory: `$ProjectFileDir$`
 
-Setup a Run Configuration: 
+Setup a Run Configuration:
 
 * Executable: `target\thumbv8m.main-none-eabihf\debug\examples\nrf9160` (only selectable after first build!)
 * Download executable: `Always`

--- a/freertos-rust/src/hooks.rs
+++ b/freertos-rust/src/hooks.rs
@@ -11,11 +11,11 @@ pub struct FreeRtosHooks {
 }
 
 impl FreeRtosHooks {
-    pub fn set_on_assert(&mut self, c: Callback) -> Result<(), Callback> {
+    pub fn set_on_assert(&self, c: Callback) -> Result<(), Callback> {
         self.on_assert.set(c)
     }
 
-    fn do_on_assert(&self) {
+    pub fn do_on_assert(&self) {
         if let Some (cb) = self.on_assert.get() {
             cb()
         }

--- a/freertos-rust/src/hooks.rs
+++ b/freertos-rust/src/hooks.rs
@@ -11,11 +11,11 @@ pub struct FreeRtosHooks {
 }
 
 impl FreeRtosHooks {
-    pub fn set_on_assert(&self, c: Callback) -> Result<(), Callback> {
+    pub fn set_on_assert(&mut self, c: Callback) -> Result<(), Callback> {
         self.on_assert.set(c)
     }
 
-    pub fn do_on_assert(&self) {
+    fn do_on_assert(&self) {
         if let Some (cb) = self.on_assert.get() {
             cb()
         }


### PR DESCRIPTION
### Overview  
**Why do we need this change?**  
The FreeRTOS Rust Linux machine setup instructions in the README were outdated or unclear. Updating them ensures accurate and up-to-date guidance for setting up and running the project.  

**What has changed?**  
- Updated the README with revised FreeRTOS Rust Linux machine setup instructions.  
- Included additional details and clarifications where necessary.  
- Changed the signature of `set_on_assert()` from taking a mutable reference (&mut self) to an immutable reference (&self)

```c
11 |     unsafe {
   |     ^^^^^^ unnecessary `unsafe` block
   |
   = note: `#[warn(unused_unsafe)]` on by default

error[E0596]: cannot borrow immutable static item `FREERTOS_HOOKS` as mutable
  --> freertos-rust-examples/examples/linux/main.rs:12:9
   |
12 |         FREERTOS_HOOKS.set_on_assert(|| { println!("Assert hook called") });
   |         ^^^^^^^^^^^^^^ cannot borrow as mutable

For more information about this error, try `rustc --explain E0596`.
warning: `freertos-rust-examples` (example "linux") generated 1 warning

```

![image](https://github.com/user-attachments/assets/2dae53b1-9866-4c2c-9abb-353f911bb848)
- Ensured that the callback functionality remains intact, with the hook being callable through the `do_on_assert()` method when an assertion occurs.

### Testing  
- [x] Linux  
**Linux console output:**
```c
~/git/FreeRTOS-rust user/jdharum..p-doc-update !1 > cargo run --example linux                                                         py platform

warning: freertos-rust-examples@0.1.1: /home/jayachandran/git/FreeRTOS-rust/freertos-rust/src/freertos/shim.c: In function 'freertos_rs_isr_yield':
warning: freertos-rust-examples@0.1.1: /home/jayachandran/git/FreeRTOS-rust/freertos-rust/src/freertos/shim.c:282:9: warning: implicit declaration of function 'portYIELD_FROM_ISR' [-Wimplicit-function-declaration]
warning: freertos-rust-examples@0.1.1:   282 |         portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
warning: freertos-rust-examples@0.1.1:       |         ^~~~~~~~~~~~~~~~~~
   Compiling freertos-rust-examples v0.1.1 (/home/jayachandran/git/FreeRTOS-rust/freertos-rust-examples)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/examples/linux`
Boxed int '15' (allocator test)
Starting FreeRTOS app ...
Task registered
Starting scheduler
Timer Resolution for Run TimeStats is 100 ticks per second.
Hello from Task! 0
Hello from Task! 1
Hello from Task! 2
Hello from Task! 3
Hello from Task! 4
Hello from Task! 5
Hello from Task! 6
^C
```