### PR TITLE
Mark `Task::resume_all` as unsafe

### DIFF
--- a/freertos-rust/src/task.rs
+++ b/freertos-rust/src/task.rs
@@ -123,7 +123,11 @@ impl Task {
       }
     }
 
-    pub fn resume_all() {
+    /// # Safety
+    ///
+    /// For every call to this method there must be a matching previous call to
+    /// `Task::suspend_all`.
+    pub unsafe fn resume_all() {
         unsafe {
             freertos_rs_xTaskResumeAll();
         }


### PR DESCRIPTION
Noticed this while working on #85. Suspending/resuming the scheduler is used for many snychonization tasks within FreeRTOS (e.g. queues), so wrongly calling `Task::resume_all` without a matching previous call to `Task::suspend_all` will wreak all sorts of havoc.
Note that I did not mark `Task::suspend_all` as `unsafe` - it should be safe to call this as often as one wants, the worst thing that happens is that the scheduler just stops doing anything, but no risk for memory safety.